### PR TITLE
Add TII architecture page; link to standalone spec repos

### DIFF
--- a/architecture/index.mdx
+++ b/architecture/index.mdx
@@ -11,4 +11,5 @@ This section contains advanced topics and design decisions that are important to
 
 <CardGrid>
   <LinkCard title="TRP" href="/tx3/architecture/trp">Transaction Resolver Protocol</LinkCard>
+  <LinkCard title="TII" href="/tx3/architecture/tii">Transaction Invocation Interface</LinkCard>
 </CardGrid>

--- a/architecture/tii.md
+++ b/architecture/tii.md
@@ -1,0 +1,24 @@
+---
+title: "Transaction Invocation Interface"
+---
+
+TII is the declarative JSON format that describes how the transactions in a Tx3 protocol can be invoked. A TII document lists the available transactions, the parameters each one accepts, the profiles (environments) those parameters can be evaluated under, and the compiled TIR bytecode the runtime needs to resolve them. TII documents are produced by `trix build`, not authored by hand.
+
+The JSON Schema spec lives at [tx3-lang/tii](https://github.com/tx3-lang/tii) (`v1beta0/tii.json`).
+
+A typical consumption flow looks like this:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Tool as Tool / UI / CLI
+    participant Resolver as TRP backend
+    Tool->>Tool: Load TII document
+    Tool->>User: Prompt for parameter values
+    User->>Tool: Provide args
+    Tool->>Resolver: trp.resolve(tir, args, env)
+    Resolver->>Tool: Signed transaction envelope
+    Tool->>Resolver: trp.submit(tx, witnesses)
+```
+
+A TII document is a stable interface contract: any tool that understands the schema — a CLI, a UI form generator, a code generator like `trix codegen` — can invoke the transactions in a protocol without knowing anything about the underlying Tx3 source.

--- a/architecture/trp.md
+++ b/architecture/trp.md
@@ -2,6 +2,8 @@
 title: "Transaction Resolver Protocol"
 ---
 
+TRP is the wire protocol that backends speak to resolve and submit Tx3 transactions. The OpenRPC spec lives at [tx3-lang/trp](https://github.com/tx3-lang/trp) (`v1beta0/trp.json`).
+
 Sequence diagram of how the Client interacts with the chain through a TRP endpoint.
 
 ```mermaid


### PR DESCRIPTION
## Summary

The TII and TRP specs now live in their own repos at [tx3-lang/tii](https://github.com/tx3-lang/tii) and [tx3-lang/trp](https://github.com/tx3-lang/trp) (see [tii#1](https://github.com/tx3-lang/tii/pull/1), [trp#5](https://github.com/tx3-lang/trp/pull/5), and [tx3#320](https://github.com/tx3-lang/tx3/pull/320), all merged). This PR surfaces both in the architecture section of the docs.

- New `architecture/tii.md` page describing the Transaction Invocation Interface alongside the existing TRP page.
- Both architecture pages now link to their canonical spec repos at the top.
- Add a TII link card to `architecture/index.mdx` so it shows up in the section's card grid.

## Test plan

- [ ] Render the site locally and confirm `/tx3/architecture/tii` resolves.
- [ ] Confirm the TII card appears next to TRP on `/tx3/architecture/`.
- [ ] Click the spec-repo links on both architecture pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)