### PR TITLE
feat: realign language section with v1beta0 spec

### DIFF
--- a/language/assets.md
+++ b/language/assets.md
@@ -1,261 +1,140 @@
 ---
-title: Asset Expressions
+title: Assets
 sidebar:
-    order: 5
+    order: 6
 ---
 
-This guide covers how to work with blockchain assets and values in Tx3.
+A UTxO carries value: a bag of `(policy, asset_name, amount)` triples. Tx3 surfaces this with the `AnyAsset` type and a small set of conveniences that make it easy to talk about quantities of specific assets without writing the policy and asset name out at every use.
 
-## Overview
+## The implicit `Ada` asset
 
-Tx3 provides built-in support for working with blockchain assets:
+`Ada` is always in scope inside `tx` bodies. You use it as a constructor — apply it to an amount to get an `AnyAsset`:
 
-- Native currency (ADA)
-- Custom tokens
-- NFTs
-- Multi-asset bundles
-
-## Asset Definitions
-
-### Native Asset (ADA)
 ```tx3
-// ADA is built-in
-Ada(1000000)  // 1 ADA
-Ada(500000)   // 0.5 ADA
+Ada(1000000)   // 1 ADA expressed in lovelace
+Ada(500000)    // 0.5 ADA
 ```
 
-### Custom Assets
-```tx3
-// Define custom asset
-asset MyToken = "policy_id" "asset_name";
+`Ada` is the only asset name the language bakes in; everything else is declared.
 
-// Use custom asset
-MyToken(100)
+## Declaring a named asset
+
+If your protocol mentions a specific asset class repeatedly, give it a name with an `asset` declaration:
+
+```tx3
+asset StaticAsset = 0xABCDEF1234."MYTOKEN";
 ```
 
-### AnyAsset Catch-All Constructor
-```tx3
-// Define custom asset and amount
-AnyAsset("policy_id", "asset_name", <amount_int>)
+The right-hand side is a policy expression, a dot, and an asset-name expression — both must have type `Bytes`. Once declared, the name can be used as a constructor like `Ada`:
 
-// Define NFT
-AnyAsset("policy_id", "asset_name", 1)
+```tx3
+StaticAsset(100)
 ```
 
-### Asset Bundles
-```tx3
-// Combine multiple assets
-Ada(1000000) + MyToken(50)
+Asset declarations live at the top level, alongside `party`, `policy`, and `type`.
 
-// Complex bundles
-Ada(1000000) + MyToken(50) + AnyAsset("policy_id", "asset_name", 1)
+## Ad-hoc assets with `AnyAsset(...)`
+
+When the policy or asset name is only known at runtime — for example because it comes from a parameter, an env value, or another input's datum — use the built-in `AnyAsset` constructor function:
+
+```tx3
+AnyAsset(policy, asset_name, quantity)
 ```
 
-## Asset Expressions
-
-### Basic Operations
-```tx3
-// Addition
-asset1 + asset2
-
-// Subtraction
-asset1 - asset2
-
-// Property access
-asset.amount
-```
-
-### Examples
+It takes a `Bytes` policy, a `Bytes` asset name, and an `Int` amount, and returns an `AnyAsset` value.
 
 ```tx3
-// Simple transfer
-tx transfer(amount: Int) {
-    input source {
-        from: Sender,
-        min_amount: Ada(amount),
-    }
-    
-    output {
-        to: Receiver,
-        amount: Ada(amount),
-    }
-}
+party Minter;
 
-// Multi-asset transfer
-tx transfer_multi(
-    ada_amount: Int,
-    token_amount: Int
+tx mint_from_local(
+    mint_policy: Bytes,
+    quantity: Int
 ) {
-    input source {
-        from: Sender,
-        min_amount: Ada(ada_amount) + MyToken(token_amount),
+    locals {
+        token: AnyAsset(mint_policy, "ABC", quantity),
     }
-    
-    output {
-        to: Receiver,
-        amount: Ada(ada_amount) + MyToken(token_amount),
-    }
-}
-```
 
-## Asset Validation
-
-### Minimum Amounts
-```tx3
-input source {
-    from: Sender,
-    min_amount: Ada(1000000),  // At least 1 ADA
-}
-```
-
-### Exact Amounts
-```tx3
-output {
-    to: Receiver,
-    amount: Ada(1000000),  // Exactly 1 ADA
-}
-```
-
-### Asset Combinations
-```tx3
-input source {
-    from: Sender,
-    min_amount: Ada(1000000) + MyToken(50),  // Multiple assets
-}
-```
-
-## Common Patterns
-
-### Token Swap
-```tx3
-tx swap(
-    input_amount: Int,
-    output_amount: Int
-) {
-    input source {
-        from: User,
-        min_amount: TokenA(input_amount),
-    }
-    
-    output {
-        to: User,
-        amount: TokenB(output_amount),
-    }
-}
-```
-
-### NFT Transfer
-```tx3
-tx transfer_nft(
-    policy_id: Bytes,
-    asset_name: Bytes
-) {
-    input source {
-        from: Owner,
-        min_amount: AnyAsset(policy_id, asset_name, 1),
-    }
-    
-    output {
-        to: Recipient,
-        amount: AnyAsset(policy_id, asset_name, 1),
-    }
-}
-
-### FT Transfer
-```tx3
-tx transfer_nft(
-    policy_id: Bytes,
-    asset_name: Bytes,
-    amount: Int
-) {
-    input source {
-        from: Owner,
-        min_amount: AnyAsset(policy_id, asset_name, amount),
-    }
-    
-    output {
-        to: Recipient,
-        amount: AnyAsset(policy_id, asset_name, amount),
-    }
-}
-```
-
-### Liquidity Pool
-```tx3
-tx add_liquidity(
-    ada_amount: Int,
-    token_amount: Int
-) {
-    input ada {
-        from: User,
-        min_amount: Ada(ada_amount),
-    }
-    
-    input token {
-        from: User,
-        min_amount: MyToken(token_amount),
-    }
-    
-    output {
-        to: Pool,
-        amount: Ada(ada_amount) + MyToken(token_amount),
-    }
-}
-```
-
-## Common Use Cases
-
-### Token Minting
-```tx3
-tx mint_tokens(
-    amount: Int
-) {
-    input source {
-        from: MintingAuthority,
-        min_amount: Ada(fees),
-    }
-    
     mint {
-        amount: MyToken(amount),
-        redeemer: MintData { quantity: amount },
+        amount: token,
+        redeemer: (),
+    }
+
+    input source {
+        from: Minter,
+        min_amount: fees,
+    }
+
+    output {
+        to: Minter,
+        amount: token - fees,
     }
 }
 ```
 
-### Token Burning
+## Adding and subtracting
+
+`AnyAsset` values combine with `+` and `-`:
+
 ```tx3
-tx burn_tokens(
-    amount: Int
-) {
+Ada(1000000) + StaticAsset(50)
+source + token - fees
+```
+
+Conceptually each operand is a bag of `(policy, asset_name, amount)` entries; addition merges and sums the amounts for matching entries, and subtraction takes the difference. There is no separate "multi-asset" type — bundles are just `AnyAsset` values that happen to carry more than one entry.
+
+The value attached to an input or reference participates in the same arithmetic: `source - Ada(quantity) - fees` makes sense because `source` is an asset value.
+
+## Reading asset components
+
+An `AnyAsset` exposes three properties:
+
+| Expression          | Type    | Meaning              |
+| ------------------- | ------- | -------------------- |
+| `asset.policy`      | `Bytes` | The asset class's policy id. |
+| `asset.asset_name`  | `Bytes` | The asset name.      |
+| `asset.amount`      | `Int`   | The quantity.        |
+
+These are useful when forwarding details into datums:
+
+```tx3
+party Sender;
+party Receiver;
+
+type TokenBundle {
+    token_id: Bytes,
+    token_name: Bytes,
+    amount: Int,
+}
+
+tx send_token(policy: Bytes, asset_name: Bytes, quantity: Int) {
     input source {
-        from: User,
-        min_amount: MyToken(amount),
+        from: Sender,
+        min_amount: AnyAsset(policy, asset_name, quantity),
     }
-    
-    burn {
-        amount: MyToken(amount),
-        redeemer: BurnData { quantity: amount },
+
+    output {
+        to: Receiver,
+        amount: AnyAsset(policy, asset_name, quantity),
+        datum: TokenBundle {
+            token_id: policy,
+            token_name: asset_name,
+            amount: quantity,
+        },
+    }
+
+    output {
+        to: Sender,
+        amount: source - AnyAsset(policy, asset_name, quantity) - fees,
     }
 }
 ```
 
-### Asset Locking
-```tx3
-tx lock_assets(
-    amount: Int
-) {
-    input source {
-        from: User,
-        min_amount: Ada(amount) + MyToken(amount),
-    }
-    
-    output locked {
-        to: LockContract,
-        amount: Ada(amount) + MyToken(amount),
-        datum: LockState {
-            amount: amount,
-            owner: User,
-        }
-    }
-}
-```
+## Common positions
+
+Asset values appear in a few specific positions:
+
+- `input { min_amount: ... }` — a lower bound on the value the resolver must find on the input.
+- `output { amount: ... }` — the exact value attached to a new output.
+- `mint { amount: ... }` / `burn { amount: ... }` — the assets minted or burnt by the transaction.
+
+For the full surface of `tx` body blocks see [Transactions](./txs).

--- a/language/cardano.md
+++ b/language/cardano.md
@@ -2,210 +2,224 @@
 title: Cardano-specific Features
 sidebar:
   label: Cardano
-  order: 6
+  order: 8
 ---
-This guide covers blockchain-specific features in Tx3 for the Cardano blockchain.
 
-### Protocol Parameters
+Most of the Tx3 language is chain-agnostic, but some transaction features are specific to one chain. On Cardano those features live under the `cardano::` namespace: stake operations, witnesses for script-using actions, reference-script publishing, treasury donations, and so on.
+
+A compiler that does not target Cardano is allowed to reject these blocks with a clear diagnostic.
+
+## `cardano::withdrawal` — claim staking rewards
+
 ```tx3
-// Access protocol parameters
-pparams.min_fee_coefficient
-pparams.min_fee_constant
-pparams.coins_per_utxo_byte
+cardano::withdrawal {
+    from: <address-like>,    // required — stake credential
+    amount: <Int>,           // required — lovelace
+    redeemer: <expr>,        // optional — for script credentials
+}
 ```
 
-### Native Scripts
-```tx3
-// Define native script
-policy TimeLock = import("validators/vesting.ak");
+The `from` field is the stake credential (a party, a policy, or any address-like expression). `amount` is a lovelace value of type `Int`. The redeemer is only meaningful when the stake credential is a script.
 
-// Use native script
-tx lock(until: Int) {
+```tx3
+party Sender;
+
+tx withdraw_rewards() {
+    cardano::withdrawal {
+        from: Sender,
+        amount: 0,
+        redeemer: (),
+    }
+}
+```
+
+A transaction may contain more than one `cardano::withdrawal` block.
+
+## `cardano::plutus_witness` — attach a Plutus script
+
+```tx3
+cardano::plutus_witness {
+    version: <Int>,          // Plutus language version (1, 2, 3, ...)
+    script: <Bytes>,         // serialized script bytes
+}
+```
+
+Both fields are optional, but the block must include at least one. The resolver pairs the witness with whichever input, mint, certificate, or withdrawal needs it.
+
+```tx3
+party Minter;
+
+tx mint_from_plutus(
+    quantity: Int
+) {
+    locals {
+       new_token: AnyAsset(0xbd3ae991b5aafccafe5ca70758bd36a9b2f872f57f6d3a1ffa0eb777, "ABC", quantity),
+    }
+
     input source {
-        from: TimeLock,
-        min_amount: Ada(amount),
+        from: Minter,
+        min_amount: fees,
+    }
+
+    collateral {
+        from: Minter,
+        min_amount: fees,
+    }
+
+    mint {
+        amount: new_token,
+        redeemer: (),
+    }
+
+    output {
+        to: Minter,
+        amount: source + new_token - fees,
+    }
+
+    cardano::plutus_witness {
+        version: 3,
+        script: 0x5101010023259800a518a4d136564004ae69,
     }
 }
 ```
 
-### Certificates
+## `cardano::native_witness` — attach a native script
+
 ```tx3
-cardano {
-    certificates: [
-        StakeRegistration { ... },
-        StakeDelegation { ... },
-        StakeDeregistration { ... },
-    ]
+cardano::native_witness {
+    script: <Bytes>,    // required — serialized native script bytes
 }
 ```
 
-### Withdrawals
-```tx3
-cardano {
-    withdrawals: [
-        (StakeCredential, Int),  // (stake credential, amount)
-    ]
-}
-```
+Used for multi-sig and other native-script credentials.
 
-### Collateral
 ```tx3
-cardano {
-    collateral: input {
-        from: User,
-        min_amount: Ada(collateral_amount),
+party Minter;
+
+tx mint_from_native_script(
+    quantity: Int
+) {
+    locals {
+       new_token: AnyAsset(0xbd3ae991b5aafccafe5ca70758bd36a9b2f872f57f6d3a1ffa0eb777, "ABC", quantity),
+    }
+
+    input source {
+        from: Minter,
+        min_amount: fees,
+    }
+
+    collateral {
+        from: Minter,
+        min_amount: fees,
+    }
+
+    mint {
+        amount: new_token,
+    }
+
+    output {
+        to: Minter,
+        amount: source + new_token - fees,
+    }
+
+    cardano::native_witness {
+        script: 0x820181820400,
     }
 }
 ```
 
-## Common Patterns
+## `cardano::treasury_donation` — pay into the treasury
 
-### Stake Registration
 ```tx3
-tx register_stake(
-    stake_credential: StakeCredential
+cardano::treasury_donation {
+    coin: <Int>,    // required — lovelace donated
+}
+```
+
+A single field, a single lovelace amount. The resolver attaches the donation to the transaction.
+
+```tx3
+cardano::treasury_donation {
+    coin: 500,
+}
+```
+
+## `cardano::stake_delegation_certificate`
+
+```tx3
+cardano::stake_delegation_certificate {
+    pool: <address-like>,    // required — pool id
+    stake: <address-like>,   // required — stake credential
+}
+```
+
+Delegates a stake credential to a pool. Both fields are required.
+
+## `cardano::vote_delegation_certificate`
+
+```tx3
+cardano::vote_delegation_certificate {
+    drep: <address-like>,    // required — DRep
+    stake: <address-like>,   // required — stake credential
+}
+```
+
+Delegates a stake credential's voting power to a DRep.
+
+```tx3
+cardano::vote_delegation_certificate {
+    drep: 0x12345678,
+    stake: 0x87654321,
+}
+```
+
+## `cardano::publish` — publish a reference script
+
+```tx3
+cardano::publish <name>? {
+    to: <address-like>,      // required — recipient
+    amount: <AnyAsset>,      // optional — value attached
+    datum: <expr>,           // optional — datum attached
+    version: <Int>,          // optional — Plutus version, omit for native
+    script: <Bytes>,         // required — script bytes to publish
+}
+```
+
+A `cardano::publish` block produces a transaction output that carries a reference script. It is in addition to any regular `output` blocks — `publish` does not replace them.
+
+```tx3
+party Sender;
+party Receiver;
+
+tx publish_plutus(
+    quantity: Int
 ) {
     input source {
-        from: User,
-        min_amount: Ada(registration_fee),
+        from: Sender,
+        min_amount: Ada(quantity),
     }
-    
-    cardano {
-        certificates: [
-            StakeRegistration {
-                credential: stake_credential,
-            }
-        ]
+
+    cardano::publish {
+        to: Receiver,
+        amount: Ada(quantity),
+        version: 3,
+        script: 0x5101010023259800a518a4d136564004ae69,
+    }
+
+    output {
+        to: Sender,
+        amount: source - Ada(quantity) - fees,
     }
 }
 ```
 
-### Stake Delegation
+For a native script, use `version: 0`:
+
 ```tx3
-tx delegate_stake(
-    stake_credential: StakeCredential,
-    pool_id: PoolId
-) {
-    input source {
-        from: User,
-        min_amount: Ada(delegation_fee),
-    }
-    
-    cardano {
-        certificates: [
-            StakeDelegation {
-                credential: stake_credential,
-                pool_id: pool_id,
-            }
-        ]
-    }
+cardano::publish {
+    to: Receiver,
+    amount: Ada(quantity),
+    version: 0,
+    script: 0x820181820400,
 }
-```
-
-### Reward Withdrawal
-```tx3
-tx withdraw_rewards(
-    stake_credential: StakeCredential,
-    amount: Int
-) {
-    input source {
-        from: User,
-        min_amount: Ada(withdrawal_fee),
-    }
-    
-    cardano {
-        withdrawals: [
-            (stake_credential, amount)
-        ]
-    }
-}
-```
-
-## Common Use Cases
-
-### Stake Pool Registration
-```tx3
-tx register_pool(
-    pool_params: PoolParams
-) {
-    input source {
-        from: Operator,
-        min_amount: Ada(registration_fee),
-    }
-    
-    cardano {
-        certificates: [
-            PoolRegistration {
-                params: pool_params,
-            }
-        ]
-    }
-}
-```
-
-### Stake Pool Retirement
-```tx3
-tx retire_pool(
-    pool_id: PoolId,
-    epoch: Int
-) {
-    input source {
-        from: Operator,
-        min_amount: Ada(retirement_fee),
-    }
-    
-    cardano {
-        certificates: [
-            PoolRetirement {
-                pool_id: pool_id,
-                epoch: epoch,
-            }
-        ]
-    }
-}
-```
-
-### Multi-Certificate Transaction
-```tx3
-tx multi_cert(
-    stake_cred: StakeCredential,
-    pool_id: PoolId
-) {
-    input source {
-        from: User,
-        min_amount: Ada(total_fee),
-    }
-    
-    cardano {
-        certificates: [
-            StakeRegistration {
-                credential: stake_cred,
-            },
-            StakeDelegation {
-                credential: stake_cred,
-                pool_id: pool_id,
-            }
-        ]
-    }
-}
-```
-
-## Network-Specific Features
-
-### Testnet Support
-```tx3
-// Network selection
-network = "testnet"
-
-// Testnet-specific parameters
-pparams.testnet = true
-```
-
-### Mainnet Support
-```tx3
-// Network selection
-network = "mainnet"
-
-// Mainnet-specific parameters
-pparams.mainnet = true
 ```

--- a/language/data.md
+++ b/language/data.md
@@ -1,277 +1,251 @@
 ---
 title: Data Expressions
 sidebar:
-    order: 4
+    order: 5
 ---
 
-This guide covers how to work with expressions in Tx3.
+Data expressions are the right-hand sides of Tx3: the values you build for datums, redeemers, amounts, slot bounds, metadata, and anywhere else the language asks for "some value of type X." This page is a reference for the syntactic ingredients — literals, operators, constructors, property access, and a handful of built-in functions — that you assemble into those values.
 
-## Overview
+## Literals
 
-Expressions in Tx3 are used to:
-
-- Compute values
-- Access properties
-- Perform operations
-- Construct data
-
-## Data Expressions
-
-### Literals
 ```tx3
-// Integer literals
+// Integer literals — type Int
 123
 -456
 0
 
-// Boolean literals
+// Boolean literals — type Bool
 true
 false
 
-// String literals
+// String literals — type Bytes
 "hello"
 "world"
 
-// Bytes literals
+// Hex literals — type Bytes
 0xDEADBEEF
 0x1234
+
+// Unit literal — type ()
+()
+
+// UTxO-reference literal — type UtxoRef
+0xABCDEF1234#0
 ```
 
-### Constructors
+Two things to notice:
+
+- A string literal is just a convenient way to write bytes. Both `"hello"` and `0x68656C6C6F` produce a `Bytes` value; there is no separate string type.
+- A `UtxoRef` literal is written as a hex transaction hash, a `#`, and an output index. The parser treats it as a single token.
+
+## Operators
+
+The operator surface is small.
+
+| Form              | Meaning                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| `expr.identifier` | Property access. Available on records, variant struct cases, `AnyAsset`, and `UtxoRef`. |
+| `expr[expr]`      | List indexing. The index expression must have type `Int`.                               |
+| `!expr`           | Arithmetic negation. Applies to `Int`.                                                  |
+| `a + b`           | Addition. `Int + Int` adds integers; `AnyAsset + AnyAsset` aggregates asset values.     |
+| `a - b`           | Subtraction. Same shapes as `+`.                                                        |
+
+Precedence, from tightest to loosest:
+
+1. Postfix `.` and `[…]`.
+2. Prefix `!`.
+3. Infix `+` and `-`.
+
+Parentheses override precedence. There are no comparison, logical, multiplication, division, or ternary operators in this version of the language.
+
+## Constructors
+
+### Records and variants
+
+A record value is built by naming the type and giving each field:
+
 ```tx3
-// Record construction
-State {
-    field1: value1,
-    field2: value2,
+type State {
+    counter: Int,
+    owner: Bytes,
 }
 
-// Variant construction
-Result::Success(42)
-Result::Error("failed")
+State {
+    counter: 0,
+    owner: 0xDEADBEEF,
+}
 ```
 
-### Binary Operations
+A variant value names the type, the case, and (for struct cases) the fields:
+
 ```tx3
-// Arithmetic
-a + b
-a - b
+type Result {
+    Ok { value: Int },
+    Err,
+}
 
-// Comparison
-a == b
-a != b
-a < b
-a > b
-a <= b
-a >= b
-
-// Logical
-a && b
-a || b
-!a
+Result::Ok { value: 42 }
+Result::Err { }
 ```
 
-### Property Access
-```tx3
-// Record field access
-record.field
+### Spread
 
-// Variant field access
-variant.field
+Inside a record or variant constructor you can copy fields from another value with `...base` and override only the ones you care about. The spread must be the last entry:
+
+```tx3
+type MyRecord {
+    field1: Int,
+    field2: Bytes,
+    field4: List<Int>,
+    field5: Map<Int, Bytes>,
+}
+
+MyRecord {
+    field1: quantity,
+    field4: [1, 2, 3, source.field1],
+    field5: {1: "Value1", 2: "Value2",},
+    ...source
+}
 ```
 
-## Asset Expressions
+Fields written explicitly take precedence; remaining fields are taken from `source`.
 
-### Asset Constructors
+### Lists and maps
+
 ```tx3
-// ADA constructor
-Ada(1000000)
+[1, 2, 3]            // List<Int>
+[]                   // empty list — type from context
 
-// Custom asset constructor
-MyToken(100)
-
-// NFT constructor
-AnyAsset(policy_id, asset_name, 1)
+{1: "Value1", 2: "Value2"}   // Map<Int, Bytes>
 ```
 
-### Asset Operations
+A `Map` literal must contain at least one entry; the first entry fixes the key and value types.
+
+## Property access
+
+Records and variant struct cases expose their named fields. `AnyAsset` and `UtxoRef` expose a fixed set of built-in properties:
+
+| Expression          | Result type | Meaning                                  |
+| ------------------- | ----------- | ---------------------------------------- |
+| `asset.policy`      | `Bytes`     | Policy id of an `AnyAsset` value.        |
+| `asset.asset_name`  | `Bytes`     | Asset name of an `AnyAsset` value.       |
+| `asset.amount`      | `Int`       | Quantity of an `AnyAsset` value.         |
+| `utxo.tx_hash`      | `Bytes`     | Transaction hash of a `UtxoRef` value.   |
+| `utxo.output_index` | `Int`       | Output index of a `UtxoRef` value.       |
+
+Accessing a property that does not exist on the value's static type is a compile error.
+
+## Built-in functions
+
+These functions are always in scope.
+
+| Call                      | Returns    | Notes                                                                                  |
+| ------------------------- | ---------- | -------------------------------------------------------------------------------------- |
+| `min_utxo(output_name)`   | `AnyAsset` | Minimum Ada the named output needs to satisfy the chain's min-UTxO rule.               |
+| `tip_slot()`              | `Int`      | The chain tip slot at resolution time. May also be written as the bare identifier `tip_slot`. |
+| `slot_to_time(slot)`      | `Int`      | Converts a slot number to a POSIX time.                                                |
+| `time_to_slot(time)`      | `Int`      | Converts a POSIX time to a slot number.                                                |
+| `concat(a, b)`            | same as `a`| Concatenates two `Bytes` values or two `List<T>` values; both arguments must have the same type. |
+| `AnyAsset(policy, name, n)` | `AnyAsset` | Builds an `AnyAsset` triple from a `(Bytes, Bytes, Int)`.                             |
+
+Worked example using `min_utxo`:
+
 ```tx3
-// Addition
-asset1 + asset2
+party Sender;
+party Receiver;
 
-// Subtraction
-asset1 - asset2
-
-// Property access
-asset.amount
-```
-
-## Common Patterns
-
-### Value Computation
-```tx3
-tx transfer(amount: Int) {
+tx transfer_min(
+    quantity: Int
+) {
     input source {
         from: Sender,
-        min_amount: Ada(amount),
+        min_amount: fees + min_utxo(minimal_utxo) + min_utxo(change),
     }
-    
-    output {
+
+    output minimal_utxo {
         to: Receiver,
-        amount: Ada(amount),
+        amount: min_utxo(minimal_utxo),
     }
-    
-    output {
+
+    output change {
+      to: Sender,
+      amount: source - fees - min_utxo(minimal_utxo),
+    }
+}
+```
+
+And using the time and slot helpers:
+
+```tx3
+party Sender;
+
+type TimestampDatum {
+    current_slot: Int,
+    expiry_slot: Int,
+}
+
+tx create_timestamp_tx(deadline: Int) {
+    input source {
+        from: Sender,
+        min_amount: Ada(2000000),
+    }
+
+    output timestamp_output {
         to: Sender,
-        amount: source - Ada(amount) - fees,
+        amount: source - fees,
+        datum: TimestampDatum {
+            current_slot: slot_to_time(tip_slot()),
+            expiry_slot: time_to_slot(deadline),
+        },
     }
 }
 ```
 
-### State Updates
+## Built-in identifiers inside `tx` bodies
+
+Two identifiers are pre-bound inside every `tx` body:
+
+- `Ada` — the chain's primary asset. It is used as a constructor: `Ada(quantity)` produces an `AnyAsset`.
+- `fees` — an `AnyAsset` value representing the transaction's fee. The resolver fills in its concrete amount; you simply add or subtract it where balancing requires.
+
 ```tx3
-tx update_state(new_value: Int) {
-    input current {
-        from: Contract,
-        datum_is: State,
-    }
-    
-    output {
-        to: Contract,
-        amount: current.amount,
-        datum: State {
-            version: current.version + 1,
-            value: new_value,
-            timestamp: current.timestamp,
-        }
-    }
+output {
+    to: Sender,
+    amount: source - Ada(quantity) - fees,
 }
 ```
 
-### Conditional Logic
+Outside `tx` bodies these identifiers are not in scope.
+
+## Reading values off inputs and references
+
+An `input` or `reference` block introduces a named value into the tx's scope. You can use that name in two ways:
+
+- As an asset value, in `+` / `-` arithmetic — `source - Ada(quantity) - fees`.
+- As a typed datum, via property access — if the block declared `datum_is: MyRecord`, then `source.field` reads a field of that record.
+
 ```tx3
-tx conditional_transfer(
-    amount: Int,
-    should_lock: Bool
-) {
+type MyRecord {
+    counter: Int,
+    other_field: Bytes,
+}
+
+party MyParty;
+
+tx increase_counter() {
     input source {
-        from: Sender,
-        min_amount: Ada(amount),
+        from: MyParty,
+        min_amount: fees,
+        datum_is: MyRecord,
     }
-    
+
     output {
-        to: should_lock ? TimeLock : Receiver,
-        amount: Ada(amount),
-        datum: should_lock ? LockData { amount } : None,
-    }
-}
-```
-
-## Expression Evaluation
-
-### Order of Operations
-1. Parentheses
-2. Property access
-3. Unary operations
-4. Binary operations
-5. Constructors
-
-### Examples
-```tx3
-// Complex expression
-(a + b) * (c - d)
-
-// Property access with operation
-record.field + value
-
-// Nested construction
-State {
-    value: (a + b) * c,
-    timestamp: current.timestamp + 1,
-}
-```
-
-## Best Practices
-
-1. **Expression Clarity**
-   - Use parentheses for clarity
-   - Break complex expressions
-   - Document assumptions
-
-2. **Type Safety**
-   - Check operand types
-   - Handle edge cases
-   - Validate results
-
-3. **Performance**
-   - Minimize computation
-   - Cache repeated values
-   - Optimize expressions
-
-4. **Error Prevention**
-   - Check for null/undefined
-   - Validate ranges
-   - Handle edge cases
-
-## Common Use Cases
-
-### Fee Calculation
-```tx3
-tx transfer_with_fee(
-    amount: Int,
-    fee_rate: Int
-) {
-    input source {
-        from: Sender,
-        min_amount: Ada(amount + (amount * fee_rate / 100)),
-    }
-    
-    output {
-        to: Receiver,
-        amount: Ada(amount),
-    }
-    
-    output {
-        to: FeeCollector,
-        amount: Ada(amount * fee_rate / 100),
-    }
-}
-```
-
-### State Transitions
-```tx3
-tx transition(
-    new_state: State
-) {
-    input current {
-        from: Contract,
-        datum_is: State,
-    }
-    
-    output {
-        to: Contract,
-        amount: current.amount,
-        datum: State {
-            version: current.version + 1,
-            state: new_state,
-            timestamp: current.timestamp + 1,
-        }
-    }
-}
-```
-
-### Asset Management
-```tx3
-tx manage_assets(
-    amounts: [Int]
-) {
-    input source {
-        from: Manager,
-        min_amount: amounts.fold(Ada(0), |acc, x| acc + Ada(x)),
-    }
-    
-    output {
-        to: Pool,
-        amount: amounts.fold(Ada(0), |acc, x| acc + Ada(x)),
+        to: MyParty,
+        amount: source - fees,
+        datum: MyRecord {
+            counter: source.counter + 1,
+            other_field: source.other_field,
+        },
     }
 }
 ```

--- a/language/env.md
+++ b/language/env.md
@@ -1,0 +1,70 @@
+---
+title: Environment
+sidebar:
+    order: 1
+---
+
+A Tx3 protocol almost always depends on values that are not known when the protocol is written: the policy id of an on-chain script, the UTxO that hosts a reference script, an oracle's stake address. Hard-coding those values would tie the protocol to a single deployment.
+
+The `env` block declares those external inputs by name and type so the rest of the protocol can use them as ordinary identifiers, and so the toolchain can supply them per profile (devnet, preview, preprod, mainnet) at build time.
+
+## Declaring an env block
+
+An `env` block is a top-level declaration that lists name/type pairs:
+
+```tx3
+env {
+    field_a: Int,
+    field_b: Bytes,
+    field_c: Bool,
+    field_d: List<Bytes>,
+}
+```
+
+Rules:
+
+- A program has at most one `env` block.
+- It must contain at least one field.
+- Fields can use any of the built-in or user-defined types — primitives, `Bytes`, `UtxoRef`, `List<T>`, records, etc.
+
+## Using env values
+
+Env fields are in scope everywhere outside type definitions: in parties, policies, asset declarations, and every clause of every `tx` block. You use them like any other identifier:
+
+```tx3
+env {
+    mint_script: UtxoRef,
+    mint_policy: Bytes,
+}
+
+party Minter;
+
+tx mint_from_env(
+    quantity: Int
+) {
+    reference myscript {
+        ref: mint_script,
+    }
+
+    mint {
+        amount: AnyAsset(mint_policy, "ABC", 1),
+        redeemer: (),
+    }
+
+    input source {
+        from: Minter,
+        min_amount: fees,
+    }
+
+    output {
+        to: Minter,
+        amount: AnyAsset(mint_policy, "ABC", 1),
+    }
+}
+```
+
+Here `mint_script` and `mint_policy` are typed env values; the parser checks that `mint_script` has type `UtxoRef` wherever a `UtxoRef` is required, and that `mint_policy` has type `Bytes` wherever a policy id is expected.
+
+## How env values get supplied
+
+The Tx3 language only declares the shape of the environment. The concrete values are supplied by the toolchain — typically by `trix` from a profile-specific env file. See the project guide for how to wire env values per network.

--- a/language/index.mdx
+++ b/language/index.mdx
@@ -7,71 +7,40 @@ sidebar:
 
 import { LinkCard } from "@astrojs/starlight/components"
 
-This guide provides a comprehensive overview of the Tx3 language, its syntax, and features.
+This guide is a tour of the Tx3 language: the keywords you write at the top level, the building blocks of a transaction template, and the expression forms you use to describe values.
 
 ## Protocol
 
-A Tx3 file describes a UTxO protocol. By protocol we mean the set of conventions required to construct the transactions that allows a user to interact with the blockchain to fulfill a goal.
+A Tx3 file describes a UTxO protocol — the set of conventions that lets a user construct the transactions they need to interact with a chain to achieve some goal. Another common word for this is *dApp*, but Tx3 deliberately stops short of that: it does not build frontends. It does, however, take care of most of the boilerplate that a frontend would otherwise have to write to talk to the chain.
 
-Another common term for protocol is a dApp, but we prefer to call them protocols to decouple it from relationship to UI artifacts. Tx3 does NOT provide a way to build frontends, but it does simplify a lot of the boilerplate that these UIs need to integrate blockchain operations.
+## What you declare
 
-## Parties
+A Tx3 file is mostly a list of top-level declarations. Each declaration introduces a name that the rest of the file can use:
 
-The first thing you need to specify in your protocol is the parties involved in the interactions.
+<LinkCard title="Environment" href="language/env" description="External inputs supplied per network (script hashes, oracle UTxOs, etc.)" />
 
-A party is an abstraction for someone or something interacting with your protocol. In technical terms, a party is just a placeholder for an on-chain address.
+<LinkCard title="Parties" href="language/parties" description="Named placeholders for the on-chain addresses your protocol interacts with" />
 
-<LinkCard title="Party Syntax" href="language/parties" description="Details on how to specify and use Parties" />
+<LinkCard title="Policies" href="language/policies" description="On-chain script credentials, declared by hash or by witness" />
 
-## Transactions
+<LinkCard title="Types" href="language/types" description="Built-in types, lists, maps, records, variants, and aliases" />
 
-The main components of a protocol are the transaction template definitions.
+<LinkCard title="Assets" href="language/assets" description="The implicit `Ada` asset, named `asset` declarations, and ad-hoc `AnyAsset` values" />
 
-A transaction describes an action that the protocol can execute. A template for transaction resembles a _function_ in the sense that it takes some arguments and returns a concrete transaction that can be submitted to the blockchain.
+## What you compute
 
-The body of a transaction template in Tx3 needs to fully describe the structure of an UTxO transaction. This includes things like inputs, outputs and how they connect to each other.
+The right-hand side of every Tx3 clause is a data expression — a literal, a constructor, a property access, or a small bit of arithmetic.
 
-<LinkCard title="Transaction Syntax" href="language/txs" description="Details on how to specify and use Transaction Templates" />
+<LinkCard title="Data Expressions" href="language/data" description="Literals, operators, constructors, property access, and built-in functions" />
 
-## Policies
+## Transaction templates
 
-Policies represent the specific logic involved with a protocol. These are usually scripts on-chain that validate actions.
+The core declaration in a Tx3 file is a `tx`: a parameterised template that the toolchain turns into a concrete, balanced transaction. A `tx` body is a collection of blocks — inputs, outputs, mints, witnesses, validity bounds, signers, metadata, locals, collateral — combined freely.
 
-Policies are used by the protocol to describe rules that govern how certain operations work. Operations like spending UTxOs, minting assets, etc.
+<LinkCard title="Transactions" href="language/txs" description="Every block you can put inside a `tx` body and how they fit together" />
 
-Policies can also act as a special kind of party of the protocol.
+## Chain-specific features
 
-<LinkCard title="Policy Syntax" href="language/policies" description="Details on how to specify and use Policies" />
+A few constructs only make sense on one chain. Cardano-specific blocks live under the `cardano::` namespace — `cardano::withdrawal`, `cardano::plutus_witness`, `cardano::publish`, certificate blocks, and so on.
 
-## Types
-
-Tx3 has a set of primitive types but it also support the definition of custom types when required.
-
-Types are used by the compiler to know how to serialize data structures when generating the concrete transactions. Types are also used to catch early errors during the static analysis of the protocol.
-
-
-<LinkCard title="Types" href="language/types" description="Details on how to specify and use Types" />
-
-## Data Expressions
-
-Tx3 supports data expression to describe and operate with data structures.
-
-Data expressions are used whenever a protocol needs to express a value in term of parameters, the result of a computation or by constructing specific types of data.
-
-The contents of datums and redeemers are expressed as data expressions.
-
-<LinkCard title="Data Expressions" href="language/data" description="Details on how to specify and use Data Expressions" />
-
-## Asset Expressions
-
-Tx3 defines specific rules for expressing assets in UTxO's value.
-
-Operating with quantities of different asset classes using normal data expressions is too verbose. Tx3 introduces specific asset expressions to simplify this task. Asset expressions provide basic math operators that can be applied to multi-class assets in a very natural way.
-
-<LinkCard title="Asset Expressions" href="language/assets" description="Details on how to specify and use Asset Expressions" />
-
-## Chain-specific Features
-
-Tx3 includes ad-hoc language artifacts to deal with constructs that are specific to a particular blockchain.
-
-<LinkCard title="Cardano Features" href="language/cardano" description="Details on how to specify and use Cardano-specific features" />
+<LinkCard title="Cardano Features" href="language/cardano" description="Stake operations, witnesses, treasury donations, reference-script publishing" />

--- a/language/parties.md
+++ b/language/parties.md
@@ -1,142 +1,59 @@
 ---
 title: Parties
 sidebar:
-    order: 1
+    order: 2
 ---
 
-Parties are one of the foundational concepts in Tx3. They represent the various actors that interact with your blockchain protocol, such as users, contracts, or services.
+A party is a named placeholder for an on-chain address. Protocols are written in terms of parties (`Sender`, `Beneficiary`, `Treasury`) rather than raw addresses so that the same code can run against many deployments and so that the role each address plays is visible at a glance.
 
-## Why Parties Matter
-
-In UTxO blockchains like Cardano, addresses control UTxOs. Rather than hardcoding addresses, Tx3 uses the concept of parties to:
-
-1. **Abstract implementation details** - Separating roles from specific addresses
-2. **Improve readability** - Making transactions easier to understand
-3. **Enable configuration** - Allowing the same protocol to work with different addresses
-4. **Support parameterization** - Letting transactions work with dynamic parties
-
-## Party Definition Syntax
-
-The basic syntax for defining a party is:
+## Declaring a party
 
 ```tx3
-party {Name};
-```
-
-Where `Name` is an alphanumeric identifier (starting with a letter) that represents this party throughout your protocol.
-
-### Simple Party Examples
-
-```tx3
-// Basic parties representing different roles
-party User;           // End user of the protocol
-party Treasury;       // Treasury that holds protocol funds
-party Oracle;         // Data provider
-```
-
-# Usage
-
-Parties define the "who" in transactions - who provides inputs and who receives outputs.
-
-## Input Sources
-
-Parties specify who controls the UTxOs that will be consumed:
-
-```tx3
-party User;
-// User is providing Ada as input
-tx deposit(amount: Int) {
-    // UTxO controlled by the User party
-    input user_tokens {
-        from: User,
-        min_amount: Ada(amount) + fees,
-    }
-
-    // Rest of transaction...
-}
-```
-
-## Output Recipients
-
-Parties specify who will receive newly created UTxOs:
-
-```tx3
+party Sender;
+party Receiver;
 party Treasury;
-// Treasury is receiving protocol fees
-tx fund() {
-  // Rest of transaction...
-  output {
-    to: Treasury,        // UTxO will be sent to Treasury's address (which can be a script address as well!)
-    amount: Ada(fee_amount),
-  }
-}
 ```
 
+A party declaration introduces a typed identifier into the program scope. The concrete address is supplied at resolution time — it is not part of the source.
 
-### Complex Party Relationships
+Identifier rules: a party name starts with a letter and contains letters, digits, and underscores. Names must be unique across the program's top-level declarations.
 
-Real-world protocols typically involve multiple parties with different roles:
+## Where a party can be used
+
+Parties are address-like values. They are accepted wherever a recipient or controlling credential is expected:
+
+- as the `from` of an `input`,
+- as the `to` of an `output` or `cardano::publish`,
+- inside a `signers` block,
+- as the `from` of a `cardano::withdrawal`,
+- as the `stake` of a stake or vote delegation certificate,
+- as the `drep` of a vote delegation certificate,
+- as the `pool` of a stake delegation certificate.
 
 ```tx3
-party EscrowContract;
-party Buyer;
-party EscrowProvider;
-party Seller;
+party Sender;
+party Receiver;
 
-tx escrow_payment(
-    seller_item_id: Bytes,
-    price: Int,
-    escrow_fee: Int,
+tx transfer(
+    quantity: Int
 ) {
-    input payment {
-        from: Buyer,
-        min_amount: Ada(price + escrow_fee) + fees,
-    }
-
-    output locked_payment {
-        to: EscrowContract,
-        amount: Ada(price),
-        datum: EscrowState {
-            buyer: Buyer,
-            seller: Seller,
-            item_id: seller_item_id,
-            amount: price,
-        }
+    input source {
+        from: Sender,
+        min_amount: Ada(quantity),
     }
 
     output {
-        to: EscrowProvider,
-        amount: Ada(escrow_fee),
+        to: Receiver,
+        amount: Ada(quantity),
     }
 
     output {
-        to: Buyer,
-        amount: payment - Ada(price + escrow_fee) - fees,
+        to: Sender,
+        amount: source - Ada(quantity) - fees,
     }
 }
 ```
 
-## Party Properties and Methods
-Parties have properties and methods that can be accessed in transactions:
+## Parties vs. policies
 
-```tx3
-// Access party's address directly
-User;
-
-// In Cardano, get party's stake credential
-Treasury.stake_credential;
-
-// In Cardano, get party's payment credential
-Treasury.payment_credential;
-```
-
-
-## Best Practices for Using Parties
-
-1. **Use descriptive names** - Names like `LiquidityProvider` are clearer than `Party1`
-
-2. **Consistent roles** - Each party should have a well-defined role in the protocol
-
-3. **Security considerations** - Be clear about which parties need to authorize actions
-
-4. **Documentation** - Document the responsibilities and expectations for each party
+When the address that controls a UTxO is itself a script, declare it as a [`policy`](./policies) rather than a party. A `party` is the right tool for an actor whose address you don't yet know; a `policy` is the right tool for a script whose hash or witness you do.

--- a/language/policies.md
+++ b/language/policies.md
@@ -1,64 +1,89 @@
 ---
 title: Policies
 sidebar:
-    order: 2
+    order: 3
 ---
 
-This section explains the Tx3 syntax for _policies_.
+A policy declares a piece of on-chain validation logic — most often a Plutus or native script. Once declared, a policy can be used wherever a script credential is expected: as the controller of an input UTxO, as the target of an output, or as the credential being delegated, withdrawn from, or witnessed.
 
-Policies represent specific logic involved with a protocol. These are usually scripts on-chain that validate actions.
+## Two forms of declaration
 
-# Definition
+### Short form: known hash
 
-To define a named policy use the following syntax:
-
-```tx3
-party {Name};
-```
-
--  `Name`: an alphanumeric string to identify a policy within the protocol.
-
-If you have a static on-chain identifier for this policy use the following syntax:
+When you already know the policy's on-chain hash (for example, because the script has been compiled and pinned), bind that hash directly:
 
 ```tx3
-policy {Name} = {Value};
+policy TimeLock = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69;
 ```
 
--  `Name`: an alphanumeric string to identify a policy within the protocol.
--  `Value`: the on-chain identifier of the policy usually represented as the hash of the script.
+The right-hand side is a hex byte string — the same byte format used elsewhere in the language.
 
-## Examples
+### Constructor form: hash, script, ref
 
-A basic policy definition with name `Validator`:
-
-```
-party Validator;
-```
-
-A policy definition with a static on-chain identifier:
-
-```
-policy Vesting = 0xABCDEF;
-```
-
-# Usage
-
-Policies can be used to specify the owner for an input UTxO:
+When you need to attach more than just the hash — for example because the transaction will carry the script inline, or read it from a reference UTxO — use the constructor form:
 
 ```tx3
-tx transfer(amount: Int) {
+policy FullyDefinedPolicy {
+    hash: 0xABCDEF1234,
+    script: 0xABCDEF1234,
+    ref: 0xABCDEF1234,
+}
+```
+
+All three fields are optional, but at least one must be present:
+
+| Field    | Meaning                                                   |
+| -------- | --------------------------------------------------------- |
+| `hash`   | The policy's script hash.                                 |
+| `script` | The serialized script bytes, to be attached inline.       |
+| `ref`    | A reference identifying where the script can be read from. |
+
+The exact way `script` and `ref` are interpreted is chain-specific — see [Cardano features](./cardano) for the witness and reference-script blocks that consume them.
+
+## Using a policy
+
+A policy identifier is address-like, just like a party. It can appear anywhere a party can:
+
+```tx3
+party Owner;
+party Beneficiary;
+
+policy TimeLock = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69;
+
+type State {
+  lock_until: Int,
+  owner: Bytes,
+  beneficiary: Bytes,
+}
+
+tx lock(
+    quantity: Int,
+    until: Int
+) {
     input source {
-        from: Validator,
+        from: Owner,
+        min_amount: Ada(quantity),
     }
-}
-```
 
-Policies can be used to specify the target for an output UTxO:
+    output target {
+        to: TimeLock,
+        amount: Ada(quantity),
+        datum: State {
+            lock_until: until,
+            owner: Owner,
+            beneficiary: Beneficiary,
+        },
+    }
 
-```tx3
-tx transfer(amount: Int) {
     output {
-        to: Vesting,
+        to: Owner,
+        amount: source - Ada(quantity) - fees,
     }
 }
 ```
+
+`Owner` is a party (the user who will lock funds), `TimeLock` is a policy (the script that will hold them). Both appear in the same positions.
+
+## Pairing a policy with a witness
+
+When the policy is a script that must be witnessed by the transaction (for example a Plutus minting policy or a script spend), the policy declaration alone is not enough — you also need to attach the script (or a reference to it) to the transaction. That is done with one of the `cardano::*_witness` blocks; see [Cardano features](./cardano).

--- a/language/txs.md
+++ b/language/txs.md
@@ -1,273 +1,395 @@
 ---
 title: Transactions
 sidebar:
-    order: 2
+    order: 7
 ---
 
-Transactions are the core of blockchain interactions, and in Tx3, they're defined as templates that generate complete, valid blockchain transactions based on parameters.
+A `tx` declares a transaction *template*: a parameterised description of a transaction that the toolchain resolves into a concrete, balanced, ready-to-submit transaction at the moment of use. The body of a `tx` is a collection of blocks — inputs, outputs, mints, witnesses, metadata, and so on — that together describe what the transaction must contain.
 
-# What Makes Tx3 Different
-Unlike most blockchain development approaches where transactions are constructed programmatically through multiple API calls, Tx3 uses a declarative approach where:
+This page walks through each block, when to reach for it, and the rules the parser enforces on it.
 
-- The entire transaction structure is visible in one place
-- Input selection is constraint-based rather than explicit
-- Transaction balancing is handled automatically
-- Asset operations are type-checked at compile time
-- Parameters provide customization without sacrificing readability
-
-# Overview
-
-Transaction templates are the core building blocks of Tx3 programs. They define patterns for constructing valid transactions by specifying:
-
-- Required inputs
-- Expected outputs
-- Validation conditions
-- Parameter bindings
-
-# Transaction Template Structure
-A Tx3 transaction template has this general form
+## Shape of a tx declaration
 
 ```tx3
-tx name(param1: Type1, param2: Type2) {
-    // Optional reference block
-    reference name {...}
-
-    // Input blocks
-    input name { ... }
-    input name2* { ... }
-
-    // Optional collateral block
-    collateral { ... }
-
-    // Output blocks
-    output { ... }
-
-    // Optional mint/burn blocks
-    mint { ... }
-    burn { ... }
-
-    // Optional chain-specific blocks
-    cardano::stake_delegation { ... }
+tx <name>(param1: Type1, param2: Type2) {
+    // body blocks, in any order
 }
 ```
 
-## Reference block
-Reference blocks define what is known as the *reference inputs* of a transaction.
-This means we can reference a set of UTxOs that will be read by a validator without consuming it.
+The parameter list may be empty. Inside the body you can place any combination of the blocks described below, in any order. Names of inputs, outputs, references, locals, and parameters share a single flat scope, so an output declared near the bottom of the body can be referenced from a `min_amount` near the top.
 
 ```tx3
-reference name  {
-  ref: DataExpr // Required: Reference to the specific UTxO
-}
-```
-## Input Blocks
+party Sender;
+party Receiver;
 
-Input blocks define the UTxOs that must be consumed by the transaction.
-
-```tx3
-input name {
-    from: Party,           // Required: who owns the UTxO
-    min_amount: AssetExpr, // Optional: minimum value required
-    datum_is: Type,        // Optional: required datum type
-    ref: DataExpr,         // Optional: reference to specific UTxO
-    redeemer: DataExpr,    // Optional: redeemer data
-}
-```
-
-The `from`, `min_amount`, `datum_is` and `ref` serve as criteria for selecting inputs during the resolution phase.
-
-The `redeemer` field is a data expressions that will be passed to the validator that controls the consumption of this particular input.
-
-### Examples
-
-```tx3
-// Basic input
-input source {
-    from: Sender,
-    min_amount: Ada(1000000),
-}
-
-// Input with datum
-input locked {
-    from: TimeLock,
-    datum_is: State,
-    redeemer: UnlockData { timestamp },
-}
-
-// Specific UTxO
-input specific {
-    ref: 0xABCDEF1234#0,
-    from: Owner,
-}
-```
-
-## Output Blocks
-
-Output blocks define the UTxOs that will be created:
-
-```tx3
-output name? {
-    to: DataExpr,      // Required: recipient address
-    amount: AssetExpr, // Required: value to send
-    datum: DataExpr,   // Optional: datum to attach
-}
-```
-
-### Examples
-
-```tx3
-// Basic output
-output {
-    to: Receiver,
-    amount: Ada(1000000),
-}
-
-// Named output with datum
-output locked {
-    to: TimeLock,
-    amount: Ada(1000000),
-    datum: State {
-        lock_until: until,
-        owner: Owner,
-        beneficiary: Beneficiary,
-    }
-}
-```
-
-## Mint/Burn Blocks
-
-Mint and burn blocks define token operations:
-
-```tx3
-mint {
-    amount: AssetExpr,  // Required: amount to mint
-    redeemer: DataExpr, // Required: minting policy data
-}
-
-burn {
-    amount: AssetExpr,  // Required: amount to burn
-    redeemer: DataExpr, // Required: burning policy data
-}
-```
-
-### Examples
-
-```tx3
-// Minting tokens
-mint {
-    amount: MyToken(100),
-    redeemer: MintData { quantity: 100 },
-}
-
-// Burning tokens
-burn {
-    amount: MyToken(50),
-    redeemer: BurnData { quantity: 50 },
-}
-```
-
-## Chain-Specific Blocks
-
-Chain-specific blocks allow for blockchain-specific features:
-
-```tx3
-cardano {
-    // Cardano-specific fields
-    collateral: InputBlock,
-    certificates: [Certificate],
-    withdrawals: [(StakeCredential, Int)],
-}
-```
-
-## Parameter Binding
-
-Templates can take parameters that are bound at runtime:
-
-```tx3
 tx transfer(
-    amount: Int,
-    recipient: Bytes,
-    message: String
+    quantity: Int
 ) {
     input source {
         from: Sender,
-        min_amount: Ada(amount),
-    }
-
-    output {
-        to: recipient,
-        amount: Ada(amount),
-        datum: Message { text: message },
-    }
-}
-```
-
-## Common Patterns
-
-### Simple Transfer
-```tx3
-tx transfer(amount: Int) {
-    input source {
-        from: Sender,
-        min_amount: Ada(amount) + fees,
+        min_amount: Ada(quantity),
     }
 
     output {
         to: Receiver,
-        amount: Ada(amount),
+        amount: Ada(quantity),
     }
 
     output {
         to: Sender,
-        amount: source - Ada(amount) - fees,
+        amount: source - Ada(quantity) - fees,
     }
 }
 ```
 
-### Time-Locked Transaction
+Two identifiers are pre-bound inside every `tx` body: `Ada` (the chain's primary asset, used as a constructor) and `fees` (the resolved transaction fee, an `AnyAsset` value).
+
+## `input` — a UTxO to consume
+
 ```tx3
-tx lock(until: Int) {
-    input source {
-        from: Owner,
-        min_amount: Ada(amount) + fees,
-    }
-
-    output locked {
-        to: TimeLock,
-        amount: Ada(amount),
-        datum: State {
-            lock_until: until,
-            owner: Owner,
-            beneficiary: Beneficiary,
-        }
-    }
-
-    output {
-        to: Owner,
-        amount: source - Ada(amount) - fees,
-    }
+input <name> {
+    from: <address-like>,    // controller of the UTxO
+    ref: <UtxoRef>,          // a specific UTxO
+    datum_is: <Type>,        // expected datum type
+    min_amount: <AnyAsset>,  // lower bound on value
+    redeemer: <expr>,        // redeemer for a script input
 }
 ```
 
-### Multi-Asset Transfer
+Every field is optional individually, but the block must give the resolver *something* to find a UTxO with: at least one of `from` or `ref` must be present.
+
+- `from` is a [party](./parties) or [policy](./policies), or any address-like expression. It constrains *who* controls the UTxO.
+- `ref` pins the input to one specific UTxO.
+- `datum_is` declares the expected datum type so that property access on the input name (`source.field`) is typed.
+- `min_amount` is a lower bound — the resolver may find a UTxO with more value than required.
+- `redeemer` is the data passed to the validator if the input sits at a script address. It can be anything; `()` is fine when the validator does not look at it.
+
+The input's `<name>` puts a value into tx scope. That value can be used both as an asset bag (in `+` / `-` arithmetic) and, if `datum_is` was set, as a typed datum.
+
+A worked example with `datum_is` and a script input:
+
 ```tx3
-tx transfer_multi(
-    ada_amount: Int,
-    token_amount: Int
+party Owner;
+party Beneficiary;
+
+policy TimeLock = 0x6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69;
+
+tx unlock(
+    locked_utxo: UtxoRef
 ) {
-    input source {
-        from: Sender,
-        min_amount: Ada(ada_amount) + MyToken(token_amount) + fees,
+    input gas {
+        from: Beneficiary,
+        min_amount: fees,
+    }
+
+    input locked {
+        from: TimeLock,
+        ref: locked_utxo,
+        redeemer: (),
+    }
+
+    collateral {
+        from: Beneficiary,
+        min_amount: fees,
+    }
+
+    output target {
+        to: Beneficiary,
+        amount: gas + locked - fees,
+    }
+}
+```
+
+### `input*` — many inputs
+
+Putting a `*` after the keyword marks the block as *many*: the resolver may match zero or more UTxOs satisfying the predicates, and the resulting value is summed. Inside the tx the name still refers to a single value — you do not have to know up front how many UTxOs the resolver will pick:
+
+```tx3
+input* pieces {
+    from: Sender,
+    min_amount: fees,
+}
+```
+
+## `output` — a UTxO to produce
+
+```tx3
+output <name>? {
+    to: <address-like>,      // recipient — required
+    amount: <AnyAsset>,      // value attached — required
+    datum: <expr>,           // optional datum
+}
+```
+
+Both `to` and `amount` are required. The output name is optional; give one if you want to refer to the output from elsewhere (`min_utxo(name)` is the common case).
+
+```tx3
+output target {
+    to: Receiver,
+    amount: Ada(quantity),
+}
+```
+
+### `output?` — optional outputs
+
+Putting a `?` after the keyword marks the output as *optional*: if its computed amount turns out to be zero during balancing, the resolver may omit it entirely. An optional output may not carry a `datum` field — the parser rejects that combination.
+
+## `reference` — read a UTxO without consuming it
+
+A reference block names a UTxO that should be visible to the transaction but not spent.
+
+```tx3
+reference <name> {
+    ref: <UtxoRef>,
+    datum_is: <Type>,    // optional, enables typed datum access
+}
+```
+
+`ref` is required. If `datum_is` is present, the reference's datum can be read via property access on the name.
+
+```tx3
+party Receiver;
+
+type OracleDatum {
+    value: Int,
+}
+
+tx consume_oracle(oracle_utxo: UtxoRef) {
+    reference oracle_data {
+        ref: oracle_utxo,
+        datum_is: OracleDatum,
     }
 
     output {
         to: Receiver,
-        amount: Ada(ada_amount) + MyToken(token_amount),
+        amount: Ada(0),
+        datum: OracleDatum {
+            value: oracle_data.value,
+        },
+    }
+}
+```
+
+## `mint` and `burn`
+
+`mint` and `burn` blocks declare assets the transaction itself creates or destroys.
+
+```tx3
+mint {
+    amount: <AnyAsset>,    // required
+    redeemer: <expr>,      // optional
+}
+
+burn {
+    amount: <AnyAsset>,
+    redeemer: <expr>,
+}
+```
+
+`amount` is required; `redeemer` is optional and only meaningful when the minting policy is a script. Both blocks may appear multiple times in the same transaction.
+
+```tx3
+mint {
+    amount: StaticAsset(100),
+    redeemer: (),
+}
+
+burn {
+    amount: StaticAsset(50),
+    redeemer: (),
+}
+```
+
+## `validity` — slot bounds
+
+```tx3
+validity {
+    since_slot: <Int>,    // both fields optional
+    until_slot: <Int>,
+}
+```
+
+Both fields are optional; the resolver translates them into the chain's validity interval. Use `tip_slot()` as a convenient lower bound:
+
+```tx3
+validity {
+    since_slot: tip_slot(),
+    until_slot: validUntil,
+}
+```
+
+At most one `validity` block per transaction.
+
+## `signers` — required signatures
+
+```tx3
+signers {
+    <address-like>,
+    <address-like>,
+}
+```
+
+Each entry is an address-like expression — a party, a policy, a hex bytes literal, or any expression of type `Address`.
+
+```tx3
+signers {
+    MyParty,
+    0x0F5B22E57FEEB5B4FD1D501B007A427C56A76884D4978FAFEF979D9C,
+}
+```
+
+## `metadata` — auxiliary key/value pairs
+
+```tx3
+metadata {
+    <Int>: <expr>,
+    <Int>: <expr>,
+}
+```
+
+Each entry's key must have type `Int`. Values can be any expression. String and hex literal values must be at most 64 bytes long; values that are not literals are not size-checked at compile time but must still respect the chain's limit at resolution time.
+
+```tx3
+metadata {
+    1: metadata,
+    2: "Additional Metadata",
+}
+```
+
+A metadata block must contain at least one entry.
+
+## `locals` — named sub-expressions
+
+When the same expression appears in several places, lift it into `locals` and refer to it by name.
+
+```tx3
+locals {
+    new_token: AnyAsset(0xbd3ae991b5aafccafe5ca70758bd36a9b2f872f57f6d3a1ffa0eb777, "ABC", quantity),
+}
+```
+
+Local names share the flat tx scope, so they must not collide with parameters, input names, output names, or reference names. A `locals` block must have at least one assignment.
+
+## `collateral` — script-execution collateral
+
+For chains that require collateral on script transactions, declare it at the top level of the `tx`:
+
+```tx3
+collateral {
+    from: <address-like>,     // optional
+    min_amount: <AnyAsset>,   // optional
+    ref: <UtxoRef>,           // optional
+}
+```
+
+The block carries no identifier — collateral is consumed by the chain, not referenced by other blocks.
+
+```tx3
+collateral {
+    from: Beneficiary,
+    min_amount: fees,
+}
+```
+
+The collateral block is chain-dependent: compilers targeting chains that have no notion of collateral may warn or reject it.
+
+## Chain-specific blocks
+
+Constructs that only make sense on a particular chain live under a chain namespace. Cardano-specific blocks are prefixed with `cardano::` — for example `cardano::withdrawal`, `cardano::plutus_witness`, `cardano::publish`. See [Cardano features](./cardano) for the full list.
+
+## Putting it together
+
+A tx that exercises most of the surface above:
+
+```tx3
+env {
+    field_a: Int,
+}
+
+party MyParty;
+
+type MyRecord {
+    field1: Int,
+    field2: Bytes,
+    field3: Bytes,
+    field4: List<Int>,
+    field5: Map<Int, Bytes>,
+}
+
+type MyVariant {
+    Case1 {
+        field1: Int,
+        field2: Bytes,
+        field3: Int,
+    },
+    Case2,
+}
+
+asset StaticAsset = 0xABCDEF1234."MYTOKEN";
+
+tx my_tx(
+    quantity: Int,
+    validUntil: Int,
+    metadata: Bytes,
+) {
+    input source {
+        from: MyParty,
+        datum_is: MyRecord,
+        min_amount: Ada(quantity) + min_utxo(named_output),
+        redeemer: MyVariant::Case1 {
+            field1: field_a,
+            field2: 0xAFAFAF,
+            field3: quantity,
+        },
     }
 
-    output {
-        to: Sender,
-        amount: source - (Ada(ada_amount) + MyToken(token_amount)) - fees,
+    mint {
+        amount: StaticAsset(100),
+        redeemer: (),
+    }
+
+    burn {
+        amount: StaticAsset(50),
+        redeemer: (),
+    }
+
+    collateral {
+        ref: 0xABCDEF#1,
+    }
+
+    reference ref_block {
+        ref: 0xABCDEF#2,
+    }
+
+    output named_output {
+        to: MyParty,
+        datum: MyRecord {
+            field1: quantity,
+            field2: (54 + 10) - (8 + 2),
+            field4: [1, 2, 3, source.field1],
+            field5: {1: "Value1", 2: "Value2",},
+            ...source
+        },
+        amount: AnyAsset(source.field3, source.field2, source.field1) + Ada(40) + min_utxo(named_output),
+    }
+
+    signers {
+        MyParty,
+        0x0F5B22E57FEEB5B4FD1D501B007A427C56A76884D4978FAFEF979D9C,
+    }
+
+    validity {
+        since_slot: tip_slot(),
+        until_slot: validUntil,
+    }
+
+    metadata {
+        1: metadata,
+        2: "Additional Metadata",
+    }
+
+    locals {
+        local_var: concat("Lang", "Tour"),
     }
 }
 ```

--- a/language/types.md
+++ b/language/types.md
@@ -1,166 +1,144 @@
 ---
 title: Types
 sidebar:
-    order: 3
+    order: 4
 ---
 
-This guide covers the data types available in Tx3 and how to use them.
+Every value in Tx3 has a static type. Types let the compiler check that datums, redeemers, and parameters fit together before the transaction is ever resolved, and they tell the codegen frontends how to (de)serialize values across the language boundary.
 
-## Built-in Types
+This page is a tour of the type system: the built-in types, the compound types, and the user-defined types you build on top of them. For the literals and operators that produce values of these types, see [Data expressions](./data).
 
-### Integer (`Int`)
+## Built-in primitive types
+
+| Type       | What it holds                                                                  |
+| ---------- | ------------------------------------------------------------------------------ |
+| `Int`      | A signed integer.                                                              |
+| `Bool`     | `true` or `false`.                                                             |
+| `Bytes`    | A finite-length byte string. String literals (`"abc"`) and hex literals (`0xDEADBEEF`) both produce values of type `Bytes`. |
+| `Address`  | A chain address. The on-wire representation is defined by the target chain.    |
+| `UtxoRef`  | A reference to a specific UTxO — a `(tx_hash, output_index)` pair.             |
+| `AnyAsset` | A `(policy, asset_name, amount)` triple representing some quantity of one asset class. |
+
+There is no separate `String` type: text and arbitrary bytes share the `Bytes` type and are distinguished only by the literal you use to write them.
+
+The unit type is spelled `()`. It is mostly used as a no-op redeemer where a value is syntactically required but its content is irrelevant:
+
 ```tx3
-// Integer literals
-123
--456
-0
+mint {
+    amount: MyToken(100),
+    redeemer: (),
+}
 ```
-- Signed integer type
-- Used for quantities, timestamps, etc.
-- Supports basic arithmetic operations
 
-### Boolean (`Bool`)
+## Compound types
+
+### Lists
+
+`List<T>` is a homogeneous list of `T`. Element type is inferred from the first element or from the surrounding context.
+
 ```tx3
-// Boolean literals
-true
-false
+type Data {
+    numbers: List<Int>,
+}
 ```
-- Logical values
-- Used in conditions and flags
-- Supports logical operations
 
-### Bytes (`Bytes`)
+### Maps
+
+`Map<K, V>` is a key-value mapping with key type `K` and value type `V`. In this version of the language every `Map` literal must contain at least one entry; key and value types are inferred from that first entry.
+
 ```tx3
-// Hex string literals
-0x"deadbeef"
-0x"1234"
+type Datum {
+  A: Map<Int, Int>,
+}
 ```
-- Raw byte data
-- Used for addresses, hashes, etc.
-- Represented as hex strings
 
-### String (`String`)
-```tx3
-// String literals
-"hello"
-"world"
-```
-- Text data
-- Used for names, messages, etc.
-- UTF-8 encoded
+## User-defined types
 
-## Asset Types
-
-### Native Asset (`Ada`)
-```tx3
-// ADA literals
-Ada(1)  // 1 ADA
-Lovelace(500000)   // 0.5 ADA
-```
-- Native blockchain currency
-- Basic unit operations
-
-### Custom Assets
-```tx3
-// Asset definition
-asset MyToken = 0xABCDEF123."MYTOKEN";
-
-// Asset literals
-MyToken(100)
-```
-- User-defined tokens
-- Requires policy ID and name
-- Supports basic arithmetic
-
-## Custom Types
+User-defined types are introduced with the `type` keyword. There are three shapes.
 
 ### Records
+
+A record has a fixed set of named fields:
+
 ```tx3
-// Record definition
 type State {
     lock_until: Int,
     owner: Bytes,
     beneficiary: Bytes,
 }
+```
 
-// Record construction
+You construct a record with `TypeName { field: expr, ... }`:
+
+```tx3
 State {
     lock_until: 1234567890,
-    owner: 0x"deadbeef",
-    beneficiary: 0x"12345678",
+    owner: 0xDEADBEEF,
+    beneficiary: 0x12345678,
 }
 ```
-- Named field collections
-- Used for structured data
-- Field access via dot notation
+
+Field access uses dot notation: `state.lock_until`.
 
 ### Variants
+
+A variant type is a tagged union with one or more cases. Each case is one of three shapes:
+
 ```tx3
-// Variant definition
-type Result {
-    Success: Int,
-    Error: String,
-}
-
-// Variant construction
-Result::Success(42)
-Result::Error("failed")
-```
-- Tagged unions
-- Used for alternative values
-- Pattern matching support
-
-## Type Usage
-
-### In Parameters
-```tx3
-tx transfer(
-    amount: Int,
-    recipient: Bytes,
-    message: String
-) {
-    // ... transaction body
+type MyVariant {
+    Case1 {
+        field1: Int,
+        field2: Bytes,
+        field3: Int,
+    },
+    Case2,
 }
 ```
 
-### In Data Expressions
+- **Struct case** (`Case1` above) — has named fields, like a record case.
+- **Unit case** (`Case2` above) — carries no payload.
+- **Tuple case** — declared as `Case(T1, T2)`; accepted by the grammar but not constructable in this version of the language.
+
+You construct a variant by naming the type, the case, and (for struct cases) the fields:
+
 ```tx3
-// Record construction
-State {
-    lock_until: 1234567890,
-    owner: sender,
-    beneficiary: receiver,
+MyVariant::Case1 {
+    field1: 7,
+    field2: 0xAFAFAF,
+    field3: 42,
 }
 
-// Variant construction
-Result::Success(42)
+MyVariant::Case2 { }
 ```
 
-### In Asset Expressions
+Each case name must be unique within its variant.
+
+### Type aliases
+
+A type alias gives an existing type a second name. Aliases are transparent: an alias and the type it points to are interchangeable everywhere.
+
 ```tx3
-// ADA amount
-Ada(1000000)
+type AssetName = Bytes;
+type PolicyId = Bytes;
+type Amount = Int;
 
-// Custom token amount
-MyToken(100)
+type TokenId = PolicyId;        // alias chains are allowed
+type TokenName = AssetName;
+type Balance = Amount;
+
+type Asset {
+    token_id: TokenId,
+    token_name: TokenName,
+    amount: Balance,
+}
+
+type TokenBundle = Asset;
 ```
 
-## Type Safety
+Cyclic aliases (`type A = B; type B = A;`) are rejected.
 
-Tx3 provides several type safety features:
+## Type equivalence
 
-1. **Static Type Checking**
-   - Types are checked at compile time
-   - No runtime type errors
-   - Clear error messages
+Two types are equivalent if they are the same primitive, the same `List<T>` (with equivalent `T`), the same `Map<K, V>` (with equivalent `K` and `V`), or refer to the same user-defined type after alias chasing.
 
-2. **Type Inference**
-   - Types can be inferred from context
-   - Different semantics for Data Expressions and Asset Expressions
-   - Reduces type annotations
-   - Maintains type safety
-
-3. **Type Constraints**
-   - Custom validation rules
-   - Range checks
-   - Format validation
+There are no implicit conversions. `Int` does not silently turn into `Bytes`, and `Bytes` does not silently turn into `Address`, `UtxoRef`, or `AnyAsset`. Where a position expects a specific type, the expression must already have that type.


### PR DESCRIPTION
## Summary

- Treats `tx3/specs/v1beta0` as the source of truth and rewrites every page under `docs/language/` so the documented surface matches the spec.
- Keeps a tutorial / pedagogic voice — each page leads with motivation, gives a worked example lifted from `tx3/examples/`, and only then lists the field-by-field rules.
- All complete-program snippets in the rewritten docs parse cleanly via `tx3c build` (16 / 16).

## What changed page-by-page

| Page | Change |
| --- | --- |
| `index.mdx` | Reorganised around "what you declare / what you compute / what you assemble"; added env card; corrected the chain-extensions blurb to mention `cardano::<thing>`. |
| `env.md` *(new)* | Documents `env { … }` top-level blocks. |
| `parties.md` | Dropped the invented `.stake_credential` / `.payment_credential` accessors; listed every position that accepts a party. |
| `policies.md` | Fixed the `party {Name};`-as-policy copy-paste bug; documented both the short `policy Name = 0xHEX;` form and the constructor form (`hash` / `script` / `ref`). |
| `types.md` | Dropped `String`, `Lovelace`, `0x"…"` hex form, fake pattern-matching / type-constraints sections. Added `Address`, `UtxoRef`, `AnyAsset`, `Unit`, `List<T>`, `Map<K, V>`, type aliases. Variants now show unit, struct, and tuple case shapes. |
| `data.md` | Pruned the operator surface to the real set (`+`, `-`, `!`, `.`, `[…]`) with a precedence table. Removed `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `\|\|`, `?:`, `*`, `/`, `fold`, lambdas. Added spread, list/map literals, the six built-in functions (`min_utxo`, `tip_slot`, `slot_to_time`, `time_to_slot`, `concat`, `AnyAsset`), and the `fees` / `Ada` built-in identifiers. |
| `assets.md` | Fixed the asset declaration to the dot form `asset Name = <bytes>.<bytes>;`. Documented `Ada`, `AnyAsset(…)`, and the `.policy` / `.asset_name` / `.amount` accessors. |
| `txs.md` | Full block-by-block walkthrough: `input` (incl. `input*` many-inputs and `from` XOR `ref`), `output` (incl. `output?` with the no-datum rule), `reference`, `mint`/`burn` (with `redeemer` correctly marked optional), `validity`, `signers`, `metadata` (with the Int-key / ≤64-byte-literal-value rules), `locals`, top-level `collateral`. |
| `cardano.md` | Discarded the entire invented `cardano { certificates: [...], withdrawals: [...] }` surface (`import()`, `pparams.*`, `network = "..."`, `StakeRegistration`, `PoolRegistration`, etc.). Documented the seven real `cardano::*` blocks (`withdrawal`, `plutus_witness`, `native_witness`, `treasury_donation`, `stake_delegation_certificate`, `vote_delegation_certificate`, `publish`) with worked examples lifted from `tx3/examples/`. |

## Verification

- Extracted every fenced `\`\`\`tx3` block from the eight rewritten pages: 16 complete-program snippets, all parsed by `tx3c build`. The remaining 50 are intentional fragments (single blocks, bare expressions).
- Grep across `docs/language/` for invented forms (`==`, `\|\|`, `?:`-style, `pparams`, `import(`, `network = "`, `Lovelace(`, `0x"`, `cardano {`, `StakeRegistration` / `StakeDelegation` / `StakeDeregistration` / `PoolRegistration` / `PoolRetirement`, `StakeCredential`, `PoolId`, `PoolParams`, `fold(`): zero hits in code; the few prose matches are legitimate ("there is no `String` type", the `<name>?` optional-output marker, the metadata size-rule sentence).

## Test plan

- [ ] Skim each rewritten page in a local Starlight build and confirm rendering / nav order (env → parties → policies → types → data → assets → txs → cardano).
- [ ] Spot-check links between pages (parties ↔ policies ↔ cardano).
- [ ] Re-run the snippet parse check after any review-driven edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)