### PR TITLE
refactor: restructure landing page and reorder sidebar

### DIFF
--- a/consuming/_meta.yml
+++ b/consuming/_meta.yml
@@ -1,3 +1,3 @@
 label: Consuming Protocols
-order: 6
+order: 4
 collapsed: true

--- a/examples/_meta.yml
+++ b/examples/_meta.yml
@@ -1,3 +1,3 @@
 label: Examples
-order: 5
+order: 6
 collapsed: true

--- a/index.mdx
+++ b/index.mdx
@@ -9,14 +9,6 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 Tx3 is an interface description format for UTxO blockchain protocols, plus the tooling to author and consume those interfaces. Protocol authors define a spec that declares what their protocol exposes; consumers read that spec and generate typed clients to build the transactions it accepts.
 
-## Two sides of the workflow
-
-The same spec serves two audiences: the protocol author who publishes it, and the application developer who consumes it.
-
-**Authoring.** Protocol authors write a `.tx3` file declaring the parties involved, the assets at stake, the transaction templates a user can invoke, and the rules each one must satisfy. The Tx3 toolchain parses, type-checks, and analyses the file, and emits a publishable interface artifact (the TII).
-
-**Consuming.** Application developers point at a compiled interface (the `.tii` file) and get typed SDKs in TypeScript, Rust, Go, and Python. At runtime, the SDKs speak the Transaction Resolver Protocol (TRP) to a backend that turns the invocation into an un-signed transaction.
-
 ## Why UTxO protocols need this
 
 In Web2, an HTTP API is described with OpenAPI: a machine-readable spec listing every endpoint, the shape of each request, and the shape of each response. With that spec in hand, any consumer can generate a typed client and start calling the API without reading the server's source.
@@ -26,6 +18,22 @@ The EVM ecosystem solves the same problem at the contract layer. Every contract 
 UTxO chains have nothing equivalent. A dApp is a set of validators that accept or reject transactions; nothing in the chain tells you which UTxOs to spend, which datums to attach, which redeemers to supply, which scripts to witness. That knowledge usually lives in the protocol author's head, or in a hand-written SDK that consumers have to reverse-engineer.
 
 Tx3 makes that knowledge a first-class, machine-readable artifact: the protocol's interface, written down.
+
+## Pick your lane
+
+The same spec serves two audiences: the protocol author who publishes it, and the application developer who consumes it.
+
+The docs are organised around the two audiences. Start with the side that matches what you're trying to do.
+
+**Authoring.** Protocol authors write a `.tx3` file declaring the parties involved, the assets at stake, the transaction templates a user can invoke, and the rules each one must satisfy. The Tx3 toolchain parses, type-checks, and analyses the file, and emits a publishable interface artifact (the TII).
+
+<LinkCard title="Authoring Protocols" href="/tx3/authoring">Write `.tx3` files describing the transactions your protocol exposes — language guide, examples, devnet, testing.</LinkCard>
+
+**Consuming.** Application developers point at a compiled interface (the `.tii` file) and get typed SDKs in TypeScript, Rust, Go, and Python. At runtime, the SDKs speak the Transaction Resolver Protocol (TRP) to a backend that turns the invocation into an un-signed transaction.
+
+<LinkCard title="Consuming Protocols" href="/tx3/consuming">Generate a typed client from a published `.tii` and integrate it into your application — codegen, SDK references.</LinkCard>
+
+Either way, start with [Installation](/tx3/installation) to get the toolchain on your machine.
 
 ## What's in the toolkit
 
@@ -39,20 +47,17 @@ Tx3 makes that knowledge a first-class, machine-readable artifact: the protocol'
 
 Tx3 does not replace on-chain validators. Write those in your favourite language for the job — we love [Aiken](https://aiken-lang.org/) ♥️. Tx3 sits at a higher level of abstraction, describing how off-chain code interacts with on-chain validators by constructing the transactions they accept.
 
-## Pick your lane
-
-The docs are organised around the two audiences. Start with the side that matches what you're trying to do.
+## Reference
 
 <CardGrid>
-  <LinkCard title="Authoring Protocols" href="/tx3/authoring">Write `.tx3` files describing the transactions your protocol exposes — language guide, examples, devnet, testing.</LinkCard>
-  <LinkCard title="Consuming Protocols" href="/tx3/consuming">Generate a typed client from a published `.tii` and integrate it into your application — codegen, SDK references.</LinkCard>
+  <LinkCard title="Language Guide" href="/tx3/language">Top-level declarations, transaction blocks, types, and expression syntax.</LinkCard>
+  <LinkCard title="Examples" href="/tx3/examples">Worked snippets organised by what you're trying to build.</LinkCard>
+  <LinkCard title="Tooling Reference" href="/tx3/tooling">Install, CLI command surface, editor extension.</LinkCard>
 </CardGrid>
 
-Either way, start with [Installation](/tx3/installation) to get the toolchain on your machine.
-
-## Tooling and reference
+## Advanced Topics
 
 <CardGrid>
-  <LinkCard title="Tooling Reference" href="/tx3/tooling">Install, CLI command surface, editor extension.</LinkCard>
-  <LinkCard title="Advanced" href="/tx3/advanced">The wire-format protocols underneath: TII and TRP.</LinkCard>
+  <LinkCard title="TRP" href="/tx3/advanced/trp">Transaction Resolver Protocol</LinkCard>
+  <LinkCard title="TII" href="/tx3/advanced/tii">Transaction Invocation Interface</LinkCard>
 </CardGrid>

--- a/language/_meta.yml
+++ b/language/_meta.yml
@@ -1,3 +1,3 @@
 label: Language Guide
-order: 4
+order: 5
 collapsed: true


### PR DESCRIPTION
## Summary
- Hoist "Pick your lane" above the toolkit/why sections on the landing page and turn the two audience callouts into inline `LinkCard`s.
- Expand the reference `CardGrid` with Language Guide and Examples, and split out a new "Advanced Topics" grid for TRP and TII.
- Reorder top-level sidebar so Consuming Protocols sits next to Authoring Protocols, with Language Guide and Examples after.

## Test plan
- [ ] Run the docs site locally and verify the landing page renders the new card layout
- [ ] Verify sidebar order: Introduction → Installation → Authoring → Consuming → Language Guide → Examples → Tooling → Advanced → Community

🤖 Generated with [Claude Code](https://claude.com/claude-code)