### PR TITLE
refactor: split consuming quick-start (tabbed) from sdks (directory)

### DIFF
--- a/consuming/index.mdx
+++ b/consuming/index.mdx
@@ -13,7 +13,7 @@ This section is for **application developers** integrating an existing Tx3 proto
 If instead you're authoring the protocol itself, see [Authoring Protocols](/tx3/authoring).
 
 <CardGrid>
-  <LinkCard title="Quick Start" href="/tx3/consuming/quick-start" description="Generate a TypeScript client from a .tii and submit your first transaction end-to-end." />
+  <LinkCard title="Quick Start" href="/tx3/consuming/quick-start" description="Step-by-step walkthrough that takes you from a .tii to a submitted transaction, tabbed across TypeScript, Rust, Go, and Python." />
   <LinkCard title="Codegen" href="/tx3/consuming/codegen" description="Run `trix codegen` to produce typed bindings in TypeScript, Rust, Go, or Python." />
-  <LinkCard title="SDKs" href="/tx3/consuming/sdks" description="Walkthrough of the runtime SDK lifecycle (resolve → sign → submit → wait), tabbed across TypeScript, Rust, Go, and Python." />
+  <LinkCard title="SDKs" href="/tx3/consuming/sdks" description="Directory of the supported runtime SDKs — repositories, package registries, and install commands per language." />
 </CardGrid>

--- a/consuming/quick-start.mdx
+++ b/consuming/quick-start.mdx
@@ -6,29 +6,52 @@ sidebar:
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components"
 
-This guide walks through consuming an existing Tx3 protocol from a TypeScript application. We'll generate a typed client from a compiled `.tii`, bind parties and a signer, and drive the full `resolve → sign → submit → wait` lifecycle against a TRP server.
+This guide walks through consuming an existing Tx3 protocol from your application. We'll generate a typed client from a compiled `.tii`, bind parties and a signer, and drive the full `resolve → sign → submit → wait` lifecycle against a TRP server. Every code step is shown in TypeScript, Rust, Go, and Python — pick the tab that matches your stack and the narrative still applies.
 
 We're assuming you already have:
 
 - A Tx3 project (a `trix.toml` plus a `main.tx3`) — for example the `transfer` protocol from the [authoring quick-start](/tx3/authoring/quick-start).
 - A TRP server reachable from your machine. The simplest setup is to run `trix devnet` locally; for testnet/mainnet, point at a hosted TRP endpoint (Demeter, Blockfrost-via-TRP, etc.).
-- Node.js 18+ installed.
+- The toolchain for your target language installed (Node.js 18+, Rust 1.78+, Go 1.22+, or Python 3.10+).
 
 <Aside type="note">
-Make sure you have followed the **[installation steps](/tx3/installation)** before you attempt to follow this guideline.
+Make sure you have followed the **[installation steps](/tx3/installation)** before you attempt to follow this guide.
 </Aside>
 
 ## Configure codegen
 
-Tx3 produces typed clients via `trix codegen`. Open your project's `trix.toml` and add a `[bindings]` entry for the TypeScript target:
+Tx3 produces typed clients via `trix codegen`. Open your project's `trix.toml` and add a `[[bindings]]` entry for your target language. The `output` path is where the generated client will be written; declare more than one entry if you want to target multiple languages from the same protocol.
 
-```toml
-[[bindings]]
-plugin = "typescript"
-output = "./generated/ts"
-```
-
-The `output` path is where the generated client will be written. Add one entry per target language; here we only need TypeScript.
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```toml
+    [[bindings]]
+    plugin = "typescript"
+    output = "./generated/ts"
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```toml
+    [[bindings]]
+    plugin = "rust"
+    output = "./generated/rust"
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```toml
+    [[bindings]]
+    plugin = "go"
+    output = "./generated/go"
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```toml
+    [[bindings]]
+    plugin = "python"
+    output = "./generated/python"
+    ```
+  </TabItem>
+</Tabs>
 
 ## Generate the client
 
@@ -41,112 +64,260 @@ trix codegen
 This produces:
 
 - A `.tii` artifact describing the protocol's interface (transactions, parties, profiles).
-- A typed TypeScript module under `./generated/ts/` that imports `tx3-sdk` and exposes one builder method per `tx` declared in your `.tx3` file.
+- A typed module under the `output` directory that exposes one builder method per `tx` declared in your `.tx3` file.
 
 Re-run `trix codegen` whenever you change `main.tx3`. The generated code is meant to be checked into source control alongside your application — treat it like a lockfile, not a build artifact.
 
 ## Install the runtime SDK
 
-In the application that will *use* the generated client, install the runtime SDK:
+In the application that will *use* the generated client, install the runtime SDK. It ships the `Tx3Client`, party bindings, signer abstractions, and the TRP transport layer; the generated module wraps these in a typed surface specific to your protocol.
 
-```sh
-npm install tx3-sdk
-```
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```sh
+    npm install tx3-sdk
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```toml
+    # Cargo.toml
+    [dependencies]
+    tx3-sdk = "0.9"
+    serde_json = "1"
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```sh
+    go get github.com/tx3-lang/go-sdk/sdk
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```sh
+    pip install tx3-sdk
+    ```
+  </TabItem>
+</Tabs>
 
-The runtime SDK ships the `Tx3Client`, party bindings, signer abstractions, and the TRP transport layer. The generated module wraps these in a typed surface specific to your protocol.
+## Load the protocol
+
+The `.tii` artifact carries the protocol's interface: every transaction template, the parties it expects you to bind, the profiles it was compiled for. Each SDK exposes a `Protocol.fromFile`-shaped entry point.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { Protocol } from "tx3-sdk";
+
+    const protocol = await Protocol.fromFile("./generated/ts/transfer.tii");
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let protocol = tx3_sdk::tii::Protocol::from_file("./generated/rust/transfer.tii")?;
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import tx3 "github.com/tx3-lang/go-sdk/sdk"
+
+    protocol, err := tx3.ProtocolFromFile("./generated/go/transfer.tii")
+    if err != nil { log.Fatal(err) }
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import Protocol
+
+    protocol = Protocol.from_file("./generated/python/transfer.tii")
+    ```
+  </TabItem>
+</Tabs>
+
+## Connect to a TRP server
+
+TRP is the wire protocol the SDK uses to ask a backend "given this TIR and these arguments, produce a balanced transaction." When you run `trix devnet`, a local TRP endpoint comes up automatically. For preprod/mainnet, point at a hosted TRP server.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { TrpClient } from "tx3-sdk";
+
+    const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use tx3_sdk::trp::{Client, ClientOptions};
+
+    let trp = Client::new(ClientOptions {
+        endpoint: "http://localhost:3000/rpc".to_string(),
+        headers: None,
+    });
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import "github.com/tx3-lang/go-sdk/sdk/trp"
+
+    trpClient := tx3.NewTRPClient(trp.ClientOptions{
+        Endpoint: "http://localhost:3000",
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import TrpClient
+
+    trp = TrpClient(endpoint="http://localhost:3000/rpc")
+    ```
+  </TabItem>
+</Tabs>
+
+## Bind parties, signer, and profile
+
+Every `party` declared in the `.tx3` file needs a binding at runtime. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address. `withProfile(...)` selects which environment block (devnet/preview/preprod/mainnet) the SDK uses when it asks TRP to resolve.
+
+Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP39 mnemonic at the standard Cardano path, and a generic `Ed25519Signer` for raw key material. The snippets below show whichever flavour is most idiomatic per language.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { Tx3Client, Party, Ed25519Signer } from "tx3-sdk";
+
+    const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
+
+    const tx3 = new Tx3Client(protocol, trp)
+      .withProfile("devnet")
+      .withParty("sender", Party.signer(signer))
+      .withParty("receiver", Party.address("addr_test1..."));
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use tx3_sdk::{CardanoSigner, Party, Tx3Client};
+
+    let signer = CardanoSigner::from_mnemonic(
+        "addr_test1...",
+        "word1 word2 ... word24",
+    )?;
+
+    let tx3 = Tx3Client::new(protocol, trp)
+        .with_profile("devnet")
+        .with_party("sender", Party::signer(signer))
+        .with_party("receiver", Party::address("addr_test1..."));
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import "github.com/tx3-lang/go-sdk/sdk/signer"
+
+    mySigner, err := signer.CardanoSignerFromMnemonic(
+        "addr_test1...",
+        "word1 word2 ... word24",
+    )
+    if err != nil { log.Fatal(err) }
+
+    client := tx3.NewClient(protocol, trpClient).
+        WithProfile("devnet").
+        WithParty("sender", tx3.SignerParty(mySigner)).
+        WithParty("receiver", tx3.AddressParty("addr_test1..."))
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import CardanoSigner, Party, Tx3Client
+
+    sender_signer = CardanoSigner.from_mnemonic(
+        address="addr_test1...",
+        phrase="word1 word2 ... word24",
+    )
+
+    client = (
+        Tx3Client(protocol, trp)
+        .with_profile("devnet")
+        .with_party("sender", Party.signer(sender_signer))
+        .with_party("receiver", Party.address("addr_test1..."))
+    )
+    ```
+  </TabItem>
+</Tabs>
 
 ## Drive a transaction end-to-end
 
-Here's a minimal program that invokes the `transfer` transaction from the authoring quick-start:
+`tx("name").arg(...)` builds an invocation; the four-stage chain takes it from there. Each stage returns a typed handle for the next: `ResolvedTx → SignedTx → SubmittedTx`. `waitForConfirmed` polls the chain (via TRP) until the transaction reaches the requested stability level; `waitForFinalized` waits for stronger finality.
 
-```ts
-import {
-  Tx3Client,
-  Protocol,
-  TrpClient,
-  Party,
-  Ed25519Signer,
-  PollConfig,
-} from "tx3-sdk";
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { PollConfig } from "tx3-sdk";
 
-// 1. Load the compiled .tii
-const protocol = await Protocol.fromFile("./generated/ts/transfer.tii");
+    const status = await tx3
+      .tx("transfer")
+      .arg("quantity", 10_000_000n)
+      .resolve()
+      .then((r) => r.sign())
+      .then((s) => s.submit())
+      .then((sub) => sub.waitForConfirmed(PollConfig.default()));
 
-// 2. Connect to a TRP server
-const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
+    console.log(status.stage); // "confirmed"
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use tx3_sdk::PollConfig;
 
-// 3. Configure parties and a signer
-const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
+    let invocation = tx3
+        .tx("transfer")
+        .arg("quantity", json!(10_000_000))
+        .resolve()
+        .await?;
 
-const tx3 = new Tx3Client(protocol, trp)
-  .withProfile("devnet")
-  .withParty("sender", Party.signer(signer))
-  .withParty("receiver", Party.address("addr_test1..."));
+    let signed = invocation.sign()?;
+    let submitted = signed.submit().await?;
+    let status = submitted
+        .wait_for_confirmed(PollConfig::default())
+        .await?;
 
-// 4. Build, resolve, sign, submit, and wait
-const status = await tx3
-  .tx("transfer")
-  .arg("quantity", 10_000_000n)
-  .resolve()
-  .then((r) => r.sign())
-  .then((s) => s.submit())
-  .then((sub) => sub.waitForConfirmed(PollConfig.default()));
+    println!("Confirmed at stage: {:?}", status.stage);
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    ctx := context.Background()
 
-console.log(status.stage); // "confirmed"
-```
+    resolved, err := client.Tx("transfer").
+        Arg("quantity", 10_000_000).
+        Resolve(ctx)
+    if err != nil { log.Fatal(err) }
 
-Lets break it down.
+    signed, err := resolved.Sign()
+    if err != nil { log.Fatal(err) }
 
-### Loading the protocol
+    submitted, err := signed.Submit(ctx)
+    if err != nil { log.Fatal(err) }
 
-```ts
-const protocol = await Protocol.fromFile("./generated/ts/transfer.tii");
-```
+    status, err := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())
+    if err != nil { log.Fatal(err) }
 
-`Protocol` reads the `.tii` artifact your codegen step produced. The `.tii` contains every transaction template, the parties the protocol expects you to bind, and the profiles (devnet/preview/preprod/mainnet) it was compiled with.
+    fmt.Printf("Confirmed at stage %s\n", status.Stage)
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import PollConfig
 
-### Connecting to TRP
+    resolved = await client.tx("transfer").arg("quantity", 10_000_000).resolve()
+    signed = await resolved.sign()
+    submitted = await signed.submit()
 
-```ts
-const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
-```
-
-TRP is the wire protocol the SDK uses to ask a backend "given this TIR and these arguments, produce a balanced transaction." When you run `trix devnet`, a local TRP endpoint comes up automatically. For preprod/mainnet, point this at a hosted TRP server.
-
-### Binding parties
-
-```ts
-.withParty("sender", Party.signer(signer))
-.withParty("receiver", Party.address("addr_test1..."));
-```
-
-Every `party` declared in the `.tx3` file needs a binding at runtime. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address (e.g. the recipient of a transfer).
-
-### Selecting a profile
-
-```ts
-.withProfile("devnet")
-```
-
-Profiles are named environments (declared in `trix.toml`) that supply network-specific values — script hashes, oracle UTxO refs, the TRP endpoint to default to. `withProfile` selects which set the SDK will use when it asks TRP to resolve.
-
-### The resolve → sign → submit → wait pipeline
-
-```ts
-await tx3
-  .tx("transfer")
-  .arg("quantity", 10_000_000n)
-  .resolve()        // TRP returns an unsigned tx
-  .then((r) => r.sign())     // Registered signers produce witnesses
-  .then((s) => s.submit())   // Tx + witnesses go back through TRP
-  .then((sub) => sub.waitForConfirmed(PollConfig.default()));
-```
-
-Each stage returns a typed handle for the next: `ResolvedTx → SignedTx → SubmittedTx`. `waitForConfirmed` polls the chain (via TRP) until the transaction reaches the requested stability level.
+    status = await submitted.wait_for_confirmed(PollConfig.default())
+    print(f"Confirmed at stage: {status.stage}")
+    ```
+  </TabItem>
+</Tabs>
 
 ## What's next
 
-- Read the [SDKs walkthrough](/tx3/consuming/sdks) for the same lifecycle in Rust, Go, and Python.
-- For browser usage, CIP-30 wallet integration, manual witness attachment, and the low-level TRP client, see the canonical [`tx3-sdk` README on npm](https://www.npmjs.com/package/tx3-sdk).
+- Find the canonical repository and package registry for each SDK on the [SDKs page](/tx3/consuming/sdks).
 - Learn more about the [codegen workflow](/tx3/consuming/codegen) — supported targets, output layout, and how to wire generated code into your build.
 - Understand the [protocols underneath](/tx3/advanced) (TII, TRP) if you want to know how the wire format works.

--- a/consuming/sdks.mdx
+++ b/consuming/sdks.mdx
@@ -4,265 +4,53 @@ sidebar:
   order: 3
 ---
 
-import { Tabs, TabItem, LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-A Tx3 SDK is a small runtime library that loads a compiled `.tii` protocol, binds the parties and signers your application supplies, and drives the four-stage transaction lifecycle through a TRP server: **resolve → sign → submit → wait**. The conceptual surface is identical across every supported language; only the syntax differs. This page walks the lifecycle once, in language-agnostic prose, with tabbed code snippets so you can read the version that matches your stack.
+A Tx3 SDK is the runtime library your application uses to consume a Tx3 protocol. It loads a compiled `.tii`, binds parties and signers, and drives the four-stage transaction lifecycle through a TRP server: `resolve → sign → submit → wait`.
 
-For exhaustive per-language API reference (browser/CIP-30 wallets, Cargo features, framework integrations, manual witness attachment, and so on) see each SDK's canonical README on its package registry — links at the bottom of the page.
+The conceptual surface is identical across every supported language; only the syntax differs. For a step-by-step walkthrough of that lifecycle in your language of choice, see the [Quick Start](/tx3/consuming/quick-start).
 
-## Install
+This page is a directory: each supported language, where its source lives, and where to install it from.
 
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```bash
-    npm install tx3-sdk
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```toml
-    # Cargo.toml
-    [dependencies]
-    tx3-sdk = "0.9"
-    serde_json = "1"
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```bash
-    go get github.com/tx3-lang/go-sdk/sdk
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```bash
-    pip install tx3-sdk
-    ```
-  </TabItem>
-</Tabs>
+## TypeScript
 
-## Load the protocol
+The TypeScript SDK targets Node.js, modern browsers, Bun, and Deno. It ships CIP-30 wallet bridges and bundler plugins (Vite, Rollup, Next.js) so consumers can generate clients at build time instead of committing them.
 
-The `.tii` artifact carries the protocol's interface: every transaction template, the parties it expects you to bind, the profiles it was compiled for. Each SDK exposes a `Protocol.fromFile`-shaped entry point.
+- **Source:** [`tx3-lang/web-sdk`](https://github.com/tx3-lang/web-sdk)
+- **Package:** [`tx3-sdk` on npm](https://www.npmjs.com/package/tx3-sdk)
+- **Install:** `npm install tx3-sdk`
 
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { Protocol } from "tx3-sdk";
+## Rust
 
-    const protocol = await Protocol.fromFile("./transfer.tii");
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    let protocol = tx3_sdk::tii::Protocol::from_file("./transfer.tii")?;
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    import tx3 "github.com/tx3-lang/go-sdk/sdk"
+The Rust SDK is the canonical reference implementation. Cargo features gate optional integrations; a low-level TRP client and custom signer hooks are exposed for callers that need to bypass the high-level builder.
 
-    protocol, err := tx3.ProtocolFromFile("transfer.tii")
-    if err != nil { log.Fatal(err) }
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import Protocol
+- **Source:** [`tx3-lang/rust-sdk`](https://github.com/tx3-lang/rust-sdk)
+- **Package:** [`tx3-sdk` on crates.io](https://crates.io/crates/tx3-sdk)
+- **Install:** `cargo add tx3-sdk`
 
-    protocol = Protocol.from_file("./transfer.tii")
-    ```
-  </TabItem>
-</Tabs>
+## Go
 
-## Connect to a TRP server
+The Go SDK exposes typed errors, a context-aware lifecycle, and a low-level TRP client for backends that need to integrate without the full builder surface.
 
-TRP is the wire protocol the SDK uses to ask a backend "given this TIR and these arguments, produce a balanced transaction." Run `trix devnet` for a local endpoint during development; for testnet/mainnet, point at a hosted TRP server.
+- **Source:** [`tx3-lang/go-sdk`](https://github.com/tx3-lang/go-sdk)
+- **Package:** [`github.com/tx3-lang/go-sdk/sdk` on pkg.go.dev](https://pkg.go.dev/github.com/tx3-lang/go-sdk/sdk)
+- **Install:** `go get github.com/tx3-lang/go-sdk/sdk`
 
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { TrpClient } from "tx3-sdk";
+## Python
 
-    const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    use tx3_sdk::trp::{Client, ClientOptions};
+The Python SDK exposes an async lifecycle, a low-level TRP client, and custom signer hooks.
 
-    let trp = Client::new(ClientOptions {
-        endpoint: "http://localhost:3000/rpc".to_string(),
-        headers: None,
-    });
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    import "github.com/tx3-lang/go-sdk/sdk/trp"
-
-    trpClient := tx3.NewTRPClient(trp.ClientOptions{
-        Endpoint: "http://localhost:3000",
-    })
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import TrpClient
-
-    trp = TrpClient(endpoint="http://localhost:3000/rpc")
-    ```
-  </TabItem>
-</Tabs>
-
-## Configure parties, signer, and profile
-
-Every `party` declared in the `.tx3` file needs a binding at runtime. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address. `withProfile(...)` selects which environment block (devnet/preview/preprod/mainnet) the SDK uses when it asks TRP to resolve.
-
-Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP39 mnemonic at the standard Cardano path, and a generic `Ed25519Signer` for raw key material. The snippets below show whichever flavour is most idiomatic per language.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { Tx3Client, Party, Ed25519Signer } from "tx3-sdk";
-
-    const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
-
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile("preprod")
-      .withParty("sender", Party.signer(signer))
-      .withParty("receiver", Party.address("addr_test1..."));
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    use tx3_sdk::{CardanoSigner, Party, Tx3Client};
-
-    let signer = CardanoSigner::from_mnemonic(
-        "addr_test1...",
-        "word1 word2 ... word24",
-    )?;
-
-    let tx3 = Tx3Client::new(protocol, trp)
-        .with_profile("preprod")
-        .with_party("sender", Party::signer(signer))
-        .with_party("receiver", Party::address("addr_test1..."));
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    import "github.com/tx3-lang/go-sdk/sdk/signer"
-
-    mySigner, err := signer.CardanoSignerFromMnemonic(
-        "addr_test1...",
-        "word1 word2 ... word24",
-    )
-    if err != nil { log.Fatal(err) }
-
-    client := tx3.NewClient(protocol, trpClient).
-        WithProfile("preprod").
-        WithParty("sender", tx3.SignerParty(mySigner)).
-        WithParty("receiver", tx3.AddressParty("addr_test1..."))
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import CardanoSigner, Party, Tx3Client
-
-    sender_signer = CardanoSigner.from_mnemonic(
-        address="addr_test1...",
-        phrase="word1 word2 ... word24",
-    )
-
-    client = (
-        Tx3Client(protocol, trp)
-        .with_profile("preprod")
-        .with_party("sender", Party.signer(sender_signer))
-        .with_party("receiver", Party.address("addr_test1..."))
-    )
-    ```
-  </TabItem>
-</Tabs>
-
-## Drive a transaction
-
-`tx("name").arg(...)` builds an invocation; the four-stage chain takes it from there. Each stage returns a typed handle for the next: `ResolvedTx → SignedTx → SubmittedTx`. `waitForConfirmed` polls the chain (via TRP) until the transaction reaches the requested stability level; `waitForFinalized` waits for stronger finality.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { PollConfig } from "tx3-sdk";
-
-    const status = await tx3
-      .tx("transfer")
-      .arg("quantity", 10_000_000n)
-      .resolve()
-      .then((r) => r.sign())
-      .then((s) => s.submit())
-      .then((sub) => sub.waitForConfirmed(PollConfig.default()));
-
-    console.log(status.stage); // "confirmed"
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    use serde_json::json;
-    use tx3_sdk::PollConfig;
-
-    let invocation = tx3
-        .tx("transfer")
-        .arg("quantity", json!(10_000_000))
-        .resolve()
-        .await?;
-
-    let signed = invocation.sign()?;
-    let submitted = signed.submit().await?;
-    let status = submitted
-        .wait_for_confirmed(PollConfig::default())
-        .await?;
-
-    println!("Confirmed at stage: {:?}", status.stage);
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    ctx := context.Background()
-
-    resolved, err := client.Tx("transfer").
-        Arg("quantity", 10_000_000).
-        Resolve(ctx)
-    if err != nil { log.Fatal(err) }
-
-    signed, err := resolved.Sign()
-    if err != nil { log.Fatal(err) }
-
-    submitted, err := signed.Submit(ctx)
-    if err != nil { log.Fatal(err) }
-
-    status, err := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())
-    if err != nil { log.Fatal(err) }
-
-    fmt.Printf("Confirmed at stage %s\n", status.Stage)
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import PollConfig
-
-    resolved = await client.tx("transfer").arg("quantity", 10_000_000).resolve()
-    signed = await resolved.sign()
-    submitted = await signed.submit()
-
-    status = await submitted.wait_for_confirmed(PollConfig.default())
-    print(f"Confirmed at stage: {status.stage}")
-    ```
-  </TabItem>
-</Tabs>
+- **Source:** [`tx3-lang/python-sdk`](https://github.com/tx3-lang/python-sdk)
+- **Package:** [`tx3-sdk` on PyPI](https://pypi.org/project/tx3-sdk/)
+- **Install:** `pip install tx3-sdk`
 
 ## Per-language reference
 
-Each SDK ships its own README with the full API surface — browser usage, CIP-30 wallet bridges, framework integrations, low-level TRP client, custom signers, error handling, and version compatibility. That README is the canonical reference and lives on each package's registry page:
+Each SDK ships its own README — the canonical reference for browser usage, CIP-30 wallet bridges, framework integrations, the low-level TRP client, custom signers, error handling, and version compatibility. It lives on each package's registry page:
 
 <CardGrid>
-  <LinkCard title="TypeScript — tx3-sdk on npm" href="https://www.npmjs.com/package/tx3-sdk" description="npm install tx3-sdk · Node.js, browsers, Bun, Deno · CIP-30 + vite/rollup/Next plugins" />
-  <LinkCard title="Rust — tx3-sdk on crates.io" href="https://crates.io/crates/tx3-sdk" description="cargo add tx3-sdk · Cargo features, low-level TRP client, custom signers" />
-  <LinkCard title="Go — go-sdk/sdk on pkg.go.dev" href="https://pkg.go.dev/github.com/tx3-lang/go-sdk/sdk" description="go get github.com/tx3-lang/go-sdk/sdk · typed errors, low-level TRP client" />
-  <LinkCard title="Python — tx3-sdk on PyPI" href="https://pypi.org/project/tx3-sdk/" description="pip install tx3-sdk · async lifecycle, low-level TRP client, custom signers" />
+  <LinkCard title="tx3-sdk on npm" href="https://www.npmjs.com/package/tx3-sdk" description="TypeScript — Node.js, browsers, Bun, Deno, CIP-30, bundler plugins" />
+  <LinkCard title="tx3-sdk on crates.io" href="https://crates.io/crates/tx3-sdk" description="Rust — Cargo features, low-level TRP client, custom signers" />
+  <LinkCard title="go-sdk on pkg.go.dev" href="https://pkg.go.dev/github.com/tx3-lang/go-sdk/sdk" description="Go — context-aware lifecycle, typed errors, low-level TRP client" />
+  <LinkCard title="tx3-sdk on PyPI" href="https://pypi.org/project/tx3-sdk/" description="Python — async lifecycle, low-level TRP client, custom signers" />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Reworks the **Consuming Protocols** section so Quick Start and SDKs no longer overlap.
- **Quick Start** is now a language-agnostic, step-by-step walkthrough that uses `<Tabs syncKey="lang">` at each code step to branch on TypeScript / Rust / Go / Python. Previously it was TypeScript-only.
- **SDKs** is now a per-language directory: one section per supported language with its source repository (`tx3-lang/web-sdk`, `tx3-lang/rust-sdk`, `tx3-lang/go-sdk`, `tx3-lang/python-sdk`), package registry, and install command. The lifecycle walkthrough that used to live here has moved into Quick Start.
- **`consuming/index.mdx`** LinkCard descriptions updated to match the new split.

## Test plan
- [ ] Build the docs site locally and verify the **Consuming → Quick Start** page renders with synced language tabs across every code block.
- [ ] Verify the **Consuming → SDKs** page renders the four language sections plus the registry LinkCard grid.
- [ ] Confirm cross-links resolve: Quick Start → SDKs, SDKs → Quick Start, and the LinkCards on `consuming/index.mdx`.
- [ ] Spot-check that all external links (npm, crates.io, pkg.go.dev, PyPI, the four `tx3-lang/*-sdk` repos) load.

Generated with [Claude Code](https://claude.com/claude-code)