### PR TITLE
chore: update tx3up URLs after up→tx3up rename

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -14,7 +14,7 @@ To start working with Tx3 you'll need to install the toolchain. The fastest way 
     You can install Tx3up on linux system using the following command:
 
     ```
-    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/up/releases/latest/download/tx3up-installer.sh | sh
+    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tx3-lang/tx3up/releases/latest/download/tx3up-installer.sh | sh
     ```
     </TabItem>
     <TabItem label="mac">

--- a/tooling/tx3up.mdx
+++ b/tooling/tx3up.mdx
@@ -13,7 +13,7 @@ The tool is primarily created for developers and users who want to use the `tx3`
 
 ## Installation
 
-You can download the appropriate binary for your operating system directly from the [latest releases page on the tx3up](https://github.com/tx3-lang/up/releases).
+You can download the appropriate binary for your operating system directly from the [latest releases page on the tx3up](https://github.com/tx3-lang/tx3up/releases).
 
 To verify that `tx3up` is installed correctly, open your terminal and run:
 


### PR DESCRIPTION
The `tx3-lang/up` repository was renamed to `tx3-lang/tx3up`. This updates the `tx3up` install command and releases-page link in the docs.

GitHub redirects keep the old URL working, so this is a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)