### PR TITLE
docs: make codegen the primary consuming flow

### DIFF
--- a/consuming/codegen.mdx
+++ b/consuming/codegen.mdx
@@ -6,49 +6,83 @@ sidebar:
 
 import { Aside } from "@astrojs/starlight/components"
 
-`trix codegen` reads a Tx3 project and produces typed client code that loads the project's compiled interface (`.tii`) and drives transactions through one of the runtime SDKs. Treat this as the bridge between an authored protocol and a consuming application.
+Codegen is the primary way to integrate a Tx3 protocol into an application. You declare the protocols you depend on, run `trix codegen`, and get typed client code that drives transactions through one of the runtime SDKs — no string-keyed transaction names, no untyped arguments. This page covers the full workflow; the [Quick Start](/tx3/consuming/quick-start) walks it end to end.
+
+## Adding a protocol with `trix use`
+
+`trix use` pulls a published protocol from a registry and records it in your `trix.toml` as an **interface** — a dependency you generate a client for:
+
+```sh
+trix use acme/transfer
+```
+
+This resolves the reference, downloads the protocol's compiled interface (`.tii`), caches it locally, and pins a concrete entry into `trix.toml`:
+
+```toml
+[interfaces.transfer]
+ref = "acme/transfer:0.1.3"
+digest = "sha256:1f3a…"
+```
+
+- **`ref`** is the resolved, concrete version. Even if you ran `trix use acme/transfer` without a version, the mutable `latest` tag is resolved to a fixed version at `use` time.
+- **`digest`** is the OCI manifest digest of the exact artifact, so codegen is reproducible across machines and CI.
+
+Protocols resolve against the default registry, `https://oci.tx3.land`. To point at a different one, add a `[registry]` section:
+
+```toml
+[registry]
+url = "https://registry.example.com"
+```
+
+You can declare as many interfaces as you need; `trix codegen` generates a client for each. To repin an interface to a newer release, run `trix use` again with `--force`. See the [`trix use`](/tx3/tooling/trix#trix-use) command reference for all flags.
 
 ## Supported targets
 
-| Target | Output | Runtime SDK it depends on |
+| Plugin | Output | Runtime SDK it depends on |
 |---|---|---|
-| `typescript` | ESM module + `.tii` | [`tx3-sdk` on npm](https://www.npmjs.com/package/tx3-sdk) |
-| `rust` | crate sources + `.tii` | [`tx3-sdk` on crates.io](https://crates.io/crates/tx3-sdk) |
-| `go` | Go package + `.tii` | [`github.com/tx3-lang/go-sdk/sdk` on pkg.go.dev](https://pkg.go.dev/github.com/tx3-lang/go-sdk/sdk) |
-| `python` | Python package + `.tii` | [`tx3-sdk` on PyPI](https://pypi.org/project/tx3-sdk/) |
+| `ts-client` | TypeScript (ESM) module | [`tx3-sdk` on npm](https://www.npmjs.com/package/tx3-sdk) |
+| `rust-client` | Rust module | [`tx3-sdk` on crates.io](https://crates.io/crates/tx3-sdk) |
+| `go-client` | Go package | [`github.com/tx3-lang/go-sdk/sdk` on pkg.go.dev](https://pkg.go.dev/github.com/tx3-lang/go-sdk/sdk) |
+| `python-client` | Python package | [`tx3-sdk` on PyPI](https://pypi.org/project/tx3-sdk/) |
 
-For the runtime API itself, see the [SDKs walkthrough](/tx3/consuming/sdks) — language-agnostic narrative with tabbed snippets per language.
+For the runtime API itself, see the [SDKs page](/tx3/consuming/sdks).
 
-## Configuring bindings
+## Configuring codegen
 
-Codegen targets are declared per project in `trix.toml` under `[[bindings]]`. Each entry pins one target language to one output directory:
+Codegen targets are declared per project in `trix.toml` under `[[codegen]]`. Each entry pairs one target language with one output directory:
 
 ```toml
-[[bindings]]
-plugin = "typescript"
-output = "./clients/ts"
+[[codegen]]
+plugin = "ts-client"
+output_dir = "src/gen"
 
-[[bindings]]
-plugin = "rust"
-output = "./clients/rust"
+[[codegen]]
+plugin = "rust-client"
+output_dir = "crates/protocol/src/gen"
 ```
 
-Running `trix codegen` writes every declared binding in one pass.
+`output_dir` is optional — when omitted it defaults to `.tx3/codegen/<plugin>/`. Running `trix codegen` writes every declared `[[codegen]]` entry in one pass.
 
 ## What gets generated
 
-For each binding, codegen emits two things:
+`trix codegen` generates a typed client for **every protocol in the project** — the project's own authored protocol plus each interface added with `trix use`. Output is laid out one subdirectory per protocol:
 
-1. **The `.tii` artifact** — the compiled interface description. This is the same artifact across every target language; it's what the runtime SDK loads via `Protocol.fromFile(...)` (or the equivalent in your language).
-2. **A typed client module** — a per-language wrapper that exposes one builder method per `tx` declared in your `.tx3`, with strongly-typed argument and return shapes derived from the protocol's type declarations.
+```
+src/gen/
+├── <project-name>/   # your own protocol
+└── transfer/         # the `transfer` interface
+```
 
-The generated client is intended to be **checked into source control** alongside the application that consumes it. Re-run `trix codegen` whenever the underlying `.tx3` changes; treat the output like a lockfile, not a transient build artifact.
+The subdirectory is always named after the protocol, so the path a client lands at never depends on how many interfaces you declared. Each generated module:
 
-## When the consumer lives in another repo
+- **embeds the compiled interface** — transactions, parties, and profiles are baked in at codegen time, so the generated client needs no `.tii` file at runtime;
+- **exposes one typed method per transaction**, with argument and return shapes derived from the protocol's type declarations.
 
-A common pattern: the protocol author publishes only the `.tii` (e.g. as a release artifact, npm package, or hosted URL), and the consuming application generates its client from that file alone, without cloning the whole `.tx3` project.
+The generated client is intended to be **checked into source control** alongside the application that consumes it. Re-run `trix codegen` whenever you `trix use` a newer interface version; treat the output like a lockfile, not a transient build artifact.
 
-In that case the consumer doesn't need `trix` — it can load the `.tii` directly through the runtime SDK and skip codegen entirely, paying for it with weaker typing (transactions are addressed by string name and arguments are dynamic). For a fully typed surface, vendor the `.tii` into the consumer repo and run `trix codegen` against it there.
+## When you can't run codegen
+
+Codegen is the recommended path, but it isn't always available — an ad-hoc script, a generic tool that handles arbitrary protocols, or a service that loads a protocol chosen at runtime. In those cases the runtime SDK can load a `.tii` directly and address transactions by string name, trading the typed surface for flexibility. See [Dynamic Usage](/tx3/consuming/dynamic-usage).
 
 ## Framework integrations
 
@@ -63,4 +97,4 @@ These are additive — they call the same codegen pipeline `trix codegen` invoke
 
 ## Reference
 
-For full CLI flag coverage (output paths, profile selection, watch mode), see the [`trix codegen`](/tx3/tooling/trix#trix-codegen) command reference.
+For full CLI flag coverage, see the [`trix use`](/tx3/tooling/trix#trix-use) and [`trix codegen`](/tx3/tooling/trix#trix-codegen) command references.

--- a/consuming/dynamic-usage.mdx
+++ b/consuming/dynamic-usage.mdx
@@ -1,0 +1,159 @@
+---
+title: Dynamic Usage
+sidebar:
+  label: Dynamic Usage
+  order: 4
+---
+
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components"
+
+[Codegen](/tx3/consuming/codegen) is the recommended way to consume a protocol — it gives you a typed client with one method per transaction. But codegen isn't always an option. When it isn't, every runtime SDK can also load a protocol **dynamically** and address its transactions by string name.
+
+Reach for the dynamic surface when:
+
+- you're writing an ad-hoc script and don't want a codegen step;
+- you're building a generic tool that handles arbitrary protocols;
+- the protocol your code runs against is chosen at runtime rather than known at build time.
+
+The trade-off is type safety: transaction names are strings and arguments are dynamic values, so mistakes surface at runtime instead of compile time.
+
+## Load the protocol
+
+Instead of importing a generated client, you load a compiled interface (`.tii`) at runtime. Each SDK exposes a `Protocol.fromFile`-shaped entry point.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { Protocol, TrpClient } from "tx3-sdk";
+
+    const protocol = await Protocol.fromFile("./transfer.tii");
+    const trp = new TrpClient({ endpoint: "http://localhost:8164" });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use tx3_sdk::trp::{Client, ClientOptions};
+
+    let protocol = tx3_sdk::tii::Protocol::from_file("./transfer.tii")?;
+    let trp = Client::new(ClientOptions {
+        endpoint: "http://localhost:8164".to_string(),
+        headers: None,
+    });
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import (
+        tx3 "github.com/tx3-lang/go-sdk/sdk"
+        "github.com/tx3-lang/go-sdk/sdk/trp"
+    )
+
+    protocol, err := tx3.ProtocolFromFile("./transfer.tii")
+    if err != nil { log.Fatal(err) }
+
+    trpClient := tx3.NewTRPClient(trp.ClientOptions{
+        Endpoint: "http://localhost:8164",
+    })
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import Protocol, TrpClient
+
+    protocol = Protocol.from_file("./transfer.tii")
+    trp = TrpClient(endpoint="http://localhost:8164")
+    ```
+  </TabItem>
+</Tabs>
+
+## Drive a transaction
+
+Build the client with `Tx3Client`, bind parties and a profile, then address the transaction by name with `tx("...")` and supply each argument with `arg(...)`. From there the lifecycle is identical to the typed flow: `resolve → sign → submit → wait`.
+
+<Tabs syncKey="lang">
+  <TabItem label="TypeScript">
+    ```ts
+    import { Tx3Client, Party, Ed25519Signer, PollConfig } from "tx3-sdk";
+
+    const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
+
+    const tx3 = new Tx3Client(protocol, trp)
+      .withProfile("local")
+      .withParty("sender", Party.signer(signer))
+      .withParty("receiver", Party.address("addr_test1..."));
+
+    const status = await tx3
+      .tx("transfer")
+      .arg("quantity", 10_000_000n)
+      .resolve()
+      .then((r) => r.sign())
+      .then((s) => s.submit())
+      .then((sub) => sub.waitForConfirmed(PollConfig.default()));
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use tx3_sdk::{CardanoSigner, Party, PollConfig, Tx3Client};
+
+    let signer = CardanoSigner::from_mnemonic("addr_test1...", "word1 ... word24")?;
+
+    let tx3 = Tx3Client::new(protocol, trp)
+        .with_profile("local")
+        .with_party("sender", Party::signer(signer))
+        .with_party("receiver", Party::address("addr_test1..."));
+
+    let status = tx3
+        .tx("transfer")
+        .arg("quantity", json!(10_000_000))
+        .resolve()
+        .await?
+        .sign()?
+        .submit()
+        .await?
+        .wait_for_confirmed(PollConfig::default())
+        .await?;
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    import "github.com/tx3-lang/go-sdk/sdk/signer"
+
+    mySigner, _ := signer.CardanoSignerFromMnemonic("addr_test1...", "word1 ... word24")
+
+    client := tx3.NewClient(protocol, trpClient).
+        WithProfile("local").
+        WithParty("sender", tx3.SignerParty(mySigner)).
+        WithParty("receiver", tx3.AddressParty("addr_test1..."))
+
+    ctx := context.Background()
+    resolved, _ := client.Tx("transfer").Arg("quantity", 10_000_000).Resolve(ctx)
+    signed, _ := resolved.Sign()
+    submitted, _ := signed.Submit(ctx)
+    status, _ := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from tx3_sdk import CardanoSigner, Party, PollConfig, Tx3Client
+
+    signer = CardanoSigner.from_mnemonic(address="addr_test1...", phrase="word1 ... word24")
+
+    client = (
+        Tx3Client(protocol, trp)
+        .with_profile("local")
+        .with_party("sender", Party.signer(signer))
+        .with_party("receiver", Party.address("addr_test1..."))
+    )
+
+    resolved = await client.tx("transfer").arg("quantity", 10_000_000).resolve()
+    signed = await resolved.sign()
+    submitted = await signed.submit()
+    status = await submitted.wait_for_confirmed(PollConfig.default())
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="tip">
+If the protocol is known at build time, prefer [codegen](/tx3/consuming/codegen) — you get the same lifecycle with typed transaction methods and compile-time argument checking.
+</Aside>

--- a/consuming/index.mdx
+++ b/consuming/index.mdx
@@ -8,12 +8,13 @@ pagefind: false
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-This section is for **application developers** integrating an existing Tx3 protocol. You start from a compiled interface artifact — a `.tii` file — and use it to drive transactions from your application code. The Tx3 toolchain generates a typed client in your language of choice, and at runtime that client speaks the Transaction Resolver Protocol (TRP) to a backend that turns each invocation into an unsigned transaction ready to be signed and submitted.
+This section is for **application developers** integrating an existing Tx3 protocol. The recommended workflow is codegen: pull a published protocol into your project with `trix use`, generate a typed client with `trix codegen`, and call one typed method per transaction from your application code. At runtime that client speaks the Transaction Resolver Protocol (TRP) to a backend that turns each invocation into an unsigned transaction ready to be signed and submitted.
 
 If instead you're authoring the protocol itself, see [Authoring Protocols](/tx3/authoring).
 
 <CardGrid>
-  <LinkCard title="Quick Start" href="/tx3/consuming/quick-start" description="Step-by-step walkthrough that takes you from a .tii to a submitted transaction, tabbed across TypeScript, Rust, Go, and Python." />
-  <LinkCard title="Codegen" href="/tx3/consuming/codegen" description="Run `trix codegen` to produce typed bindings in TypeScript, Rust, Go, or Python." />
+  <LinkCard title="Quick Start" href="/tx3/consuming/quick-start" description="Step-by-step walkthrough from `trix use` to a submitted transaction, tabbed across TypeScript, Rust, Go, and Python." />
+  <LinkCard title="Codegen" href="/tx3/consuming/codegen" description="Add protocols with `trix use` and generate typed clients with `trix codegen` in TypeScript, Rust, Go, or Python." />
   <LinkCard title="SDKs" href="/tx3/consuming/sdks" description="Directory of the supported runtime SDKs — repositories, package registries, and install commands per language." />
+  <LinkCard title="Dynamic Usage" href="/tx3/consuming/dynamic-usage" description="The untyped SDK surface — load a protocol at runtime and address transactions by name, for when codegen isn't an option." />
 </CardGrid>

--- a/consuming/quick-start.mdx
+++ b/consuming/quick-start.mdx
@@ -6,49 +6,71 @@ sidebar:
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components"
 
-This guide walks through consuming an existing Tx3 protocol from your application. We'll generate a typed client from a compiled `.tii`, bind parties and a signer, and drive the full `resolve → sign → submit → wait` lifecycle against a TRP server. Every code step is shown in TypeScript, Rust, Go, and Python — pick the tab that matches your stack and the narrative still applies.
+This guide walks through consuming an existing Tx3 protocol from your application with the **codegen workflow**: pull a published protocol with `trix use`, generate a typed client with `trix codegen`, and drive transactions through that client. Every code step is shown in TypeScript, Rust, Go, and Python — pick the tab that matches your stack and the narrative still applies.
 
 We're assuming you already have:
 
-- A Tx3 project (a `trix.toml` plus a `main.tx3`) — for example the `transfer` protocol from the [authoring quick-start](/tx3/authoring/quick-start).
-- A TRP server reachable from your machine. The simplest setup is to run `trix devnet` locally; for testnet/mainnet, point at a hosted TRP endpoint (Demeter, Blockfrost-via-TRP, etc.).
+- A Tx3 project — a directory with a `trix.toml`. `trix codegen` runs inside a project, so if you don't have one yet, run `trix init` to scaffold it.
+- A TRP server reachable from your machine. The simplest setup is `trix devnet`, which exposes a local TRP endpoint at `http://localhost:8164`; for testnet/mainnet, point at a hosted TRP endpoint (Demeter, Blockfrost-via-TRP, etc.).
 - The toolchain for your target language installed (Node.js 18+, Rust 1.78+, Go 1.22+, or Python 3.10+).
 
 <Aside type="note">
 Make sure you have followed the **[installation steps](/tx3/installation)** before you attempt to follow this guide.
 </Aside>
 
+## Add the protocol
+
+`trix use` pulls a published protocol from the registry and pins it into your `trix.toml` as an **interface**. From your project root:
+
+```sh
+trix use acme/transfer
+```
+
+This resolves the latest published version, downloads and caches its compiled interface, and records a pinned entry in `trix.toml`:
+
+```toml
+[interfaces.transfer]
+ref = "acme/transfer:0.1.3"
+digest = "sha256:1f3a…"
+```
+
+The `digest` locks the exact artifact, so every machine and CI run generates a client from the same interface. Append `:<version>` to the reference (`acme/transfer:0.1.0`) to pin a specific version instead of the latest, and pass `--alias <name>` to register the interface under a different local name.
+
+<Aside type="note">
+Protocols resolve against the default registry (`https://oci.tx3.land`). To use a different one, add a `[registry]` section with a `url` to `trix.toml`.
+</Aside>
+
 ## Configure codegen
 
-Tx3 produces typed clients via `trix codegen`. Open your project's `trix.toml` and add a `[[bindings]]` entry for your target language. The `output` path is where the generated client will be written; declare more than one entry if you want to target multiple languages from the same protocol.
+Add a `[[codegen]]` entry to `trix.toml` for each target language. `plugin` selects the language; `output_dir` is where generated code is written — it's optional and defaults to `.tx3/codegen/<plugin>/`. Declare more than one entry to target multiple languages from the same project.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```toml
-    [[bindings]]
-    plugin = "typescript"
-    output = "./generated/ts"
+    [[codegen]]
+    plugin = "ts-client"
+    output_dir = "src/gen"
     ```
   </TabItem>
   <TabItem label="Rust">
     ```toml
-    [[bindings]]
-    plugin = "rust"
-    output = "./generated/rust"
+    [[codegen]]
+    plugin = "rust-client"
+    output_dir = "src/gen"
     ```
   </TabItem>
   <TabItem label="Go">
     ```toml
-    [[bindings]]
-    plugin = "go"
-    output = "./generated/go"
+    [[codegen]]
+    plugin = "go-client"
+    output_dir = "gen"
     ```
   </TabItem>
   <TabItem label="Python">
     ```toml
-    [[bindings]]
-    plugin = "python"
-    output = "./generated/python"
+    [[codegen]]
+    plugin = "python-client"
+    output_dir = "gen"
     ```
   </TabItem>
 </Tabs>
@@ -61,16 +83,13 @@ From the project root, run:
 trix codegen
 ```
 
-This produces:
+This writes one typed module per protocol under `output_dir`: your own project lands in `<output_dir>/<project-name>/`, and each interface added with `trix use` lands in `<output_dir>/<alias>/` — so the `transfer` interface above is generated into `src/gen/transfer/`. Each module embeds the compiled interface (transactions, parties, profiles) and exposes one typed method per `tx` the protocol declares.
 
-- A `.tii` artifact describing the protocol's interface (transactions, parties, profiles).
-- A typed module under the `output` directory that exposes one builder method per `tx` declared in your `.tx3` file.
-
-Re-run `trix codegen` whenever you change `main.tx3`. The generated code is meant to be checked into source control alongside your application — treat it like a lockfile, not a build artifact.
+Re-run `trix codegen` whenever you `trix use` a new version of an interface. The generated code is meant to be checked into source control alongside your application — treat it like a lockfile, not a build artifact.
 
 ## Install the runtime SDK
 
-In the application that will *use* the generated client, install the runtime SDK. It ships the `Tx3Client`, party bindings, signer abstractions, and the TRP transport layer; the generated module wraps these in a typed surface specific to your protocol.
+The generated client is a thin typed layer: it delegates to the runtime SDK for transport, signing, and the transaction lifecycle. Install the SDK in the application that consumes the client.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
@@ -83,7 +102,6 @@ In the application that will *use* the generated client, install the runtime SDK
     # Cargo.toml
     [dependencies]
     tx3-sdk = "0.9"
-    serde_json = "1"
     ```
   </TabItem>
   <TabItem label="Go">
@@ -98,117 +116,49 @@ In the application that will *use* the generated client, install the runtime SDK
   </TabItem>
 </Tabs>
 
-## Load the protocol
+## Construct the client
 
-The `.tii` artifact carries the protocol's interface: every transaction template, the parties it expects you to bind, the profiles it was compiled for. Each SDK exposes a `Protocol.fromFile`-shaped entry point.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { Protocol } from "tx3-sdk";
-
-    const protocol = await Protocol.fromFile("./generated/ts/transfer.tii");
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    let protocol = tx3_sdk::tii::Protocol::from_file("./generated/rust/transfer.tii")?;
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    import tx3 "github.com/tx3-lang/go-sdk/sdk"
-
-    protocol, err := tx3.ProtocolFromFile("./generated/go/transfer.tii")
-    if err != nil { log.Fatal(err) }
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import Protocol
-
-    protocol = Protocol.from_file("./generated/python/transfer.tii")
-    ```
-  </TabItem>
-</Tabs>
-
-## Connect to a TRP server
-
-TRP is the wire protocol the SDK uses to ask a backend "given this TIR and these arguments, produce a balanced transaction." When you run `trix devnet`, a local TRP endpoint comes up automatically. For preprod/mainnet, point at a hosted TRP server.
-
-<Tabs syncKey="lang">
-  <TabItem label="TypeScript">
-    ```ts
-    import { TrpClient } from "tx3-sdk";
-
-    const trp = new TrpClient({ endpoint: "http://localhost:3000/rpc" });
-    ```
-  </TabItem>
-  <TabItem label="Rust">
-    ```rust
-    use tx3_sdk::trp::{Client, ClientOptions};
-
-    let trp = Client::new(ClientOptions {
-        endpoint: "http://localhost:3000/rpc".to_string(),
-        headers: None,
-    });
-    ```
-  </TabItem>
-  <TabItem label="Go">
-    ```go
-    import "github.com/tx3-lang/go-sdk/sdk/trp"
-
-    trpClient := tx3.NewTRPClient(trp.ClientOptions{
-        Endpoint: "http://localhost:3000",
-    })
-    ```
-  </TabItem>
-  <TabItem label="Python">
-    ```python
-    from tx3_sdk import TrpClient
-
-    trp = TrpClient(endpoint="http://localhost:3000/rpc")
-    ```
-  </TabItem>
-</Tabs>
-
-## Bind parties, signer, and profile
-
-Every `party` declared in the `.tx3` file needs a binding at runtime. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address. `withProfile(...)` selects which environment block (devnet/preview/preprod/mainnet) the SDK uses when it asks TRP to resolve.
+The generated `Client` already embeds the protocol interface, so you only give it a TRP endpoint, a profile, and party bindings. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address. `withProfile(...)` selects which environment block (`local`/`preview`/`preprod`/`mainnet`) the SDK uses when it asks TRP to resolve.
 
 Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP39 mnemonic at the standard Cardano path, and a generic `Ed25519Signer` for raw key material. The snippets below show whichever flavour is most idiomatic per language.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
-    import { Tx3Client, Party, Ed25519Signer } from "tx3-sdk";
+    import { Client } from "./gen/transfer";
+    import { Party, Ed25519Signer } from "tx3-sdk";
 
     const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
 
-    const tx3 = new Tx3Client(protocol, trp)
-      .withProfile("devnet")
+    const client = new Client({ endpoint: "http://localhost:8164" })
+      .withProfile("local")
       .withParty("sender", Party.signer(signer))
       .withParty("receiver", Party.address("addr_test1..."));
     ```
   </TabItem>
   <TabItem label="Rust">
     ```rust
-    use tx3_sdk::{CardanoSigner, Party, Tx3Client};
+    use tx3_sdk::{CardanoSigner, Party};
+    use transfer::Client;
 
     let signer = CardanoSigner::from_mnemonic(
         "addr_test1...",
         "word1 word2 ... word24",
     )?;
 
-    let tx3 = Tx3Client::new(protocol, trp)
-        .with_profile("devnet")
+    let client = Client::new("http://localhost:8164")
+        .with_profile("local")
         .with_party("sender", Party::signer(signer))
         .with_party("receiver", Party::address("addr_test1..."));
     ```
   </TabItem>
   <TabItem label="Go">
     ```go
-    import "github.com/tx3-lang/go-sdk/sdk/signer"
+    import (
+        tx3 "github.com/tx3-lang/go-sdk/sdk"
+        "github.com/tx3-lang/go-sdk/sdk/signer"
+        "yourapp/gen/transfer"
+    )
 
     mySigner, err := signer.CardanoSignerFromMnemonic(
         "addr_test1...",
@@ -216,15 +166,16 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     )
     if err != nil { log.Fatal(err) }
 
-    client := tx3.NewClient(protocol, trpClient).
-        WithProfile("devnet").
+    client := transfer.NewClient("http://localhost:8164").
+        WithProfile("local").
         WithParty("sender", tx3.SignerParty(mySigner)).
         WithParty("receiver", tx3.AddressParty("addr_test1..."))
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
-    from tx3_sdk import CardanoSigner, Party, Tx3Client
+    from tx3_sdk import CardanoSigner, Party
+    from gen.transfer import Client
 
     sender_signer = CardanoSigner.from_mnemonic(
         address="addr_test1...",
@@ -232,8 +183,8 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     )
 
     client = (
-        Tx3Client(protocol, trp)
-        .with_profile("devnet")
+        Client(endpoint="http://localhost:8164")
+        .with_profile("local")
         .with_party("sender", Party.signer(sender_signer))
         .with_party("receiver", Party.address("addr_test1..."))
     )
@@ -243,16 +194,15 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
 
 ## Drive a transaction end-to-end
 
-`tx("name").arg(...)` builds an invocation; the four-stage chain takes it from there. Each stage returns a typed handle for the next: `ResolvedTx → SignedTx → SubmittedTx`. `waitForConfirmed` polls the chain (via TRP) until the transaction reaches the requested stability level; `waitForFinalized` waits for stronger finality.
+Every `tx` in the protocol becomes a typed method on the client — `client.transfer(...)` here. It takes a typed argument object (no string keys, no untyped values) and returns the four-stage lifecycle chain. Each stage hands a typed handle to the next: `ResolvedTx → SignedTx → SubmittedTx`. `waitForConfirmed` polls the chain (via TRP) until the transaction reaches the requested stability level; `waitForFinalized` waits for stronger finality.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
     import { PollConfig } from "tx3-sdk";
 
-    const status = await tx3
-      .tx("transfer")
-      .arg("quantity", 10_000_000n)
+    const status = await client
+      .transfer({ quantity: 10_000_000n })
       .resolve()
       .then((r) => r.sign())
       .then((s) => s.submit())
@@ -263,16 +213,15 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
   </TabItem>
   <TabItem label="Rust">
     ```rust
-    use serde_json::json;
     use tx3_sdk::PollConfig;
+    use transfer::TransferParams;
 
-    let invocation = tx3
-        .tx("transfer")
-        .arg("quantity", json!(10_000_000))
+    let resolved = client
+        .transfer(TransferParams { quantity: 10_000_000 })
         .resolve()
         .await?;
 
-    let signed = invocation.sign()?;
+    let signed = resolved.sign()?;
     let submitted = signed.submit().await?;
     let status = submitted
         .wait_for_confirmed(PollConfig::default())
@@ -285,8 +234,8 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     ```go
     ctx := context.Background()
 
-    resolved, err := client.Tx("transfer").
-        Arg("quantity", 10_000_000).
+    resolved, err := client.
+        Transfer(transfer.TransferParams{Quantity: 10_000_000}).
         Resolve(ctx)
     if err != nil { log.Fatal(err) }
 
@@ -305,8 +254,9 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
   <TabItem label="Python">
     ```python
     from tx3_sdk import PollConfig
+    from gen.transfer import TransferParams
 
-    resolved = await client.tx("transfer").arg("quantity", 10_000_000).resolve()
+    resolved = await client.transfer(TransferParams(quantity=10_000_000)).resolve()
     signed = await resolved.sign()
     submitted = await signed.submit()
 
@@ -318,6 +268,7 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
 
 ## What's next
 
+- Learn more about the [codegen workflow](/tx3/consuming/codegen) — `trix use`, supported targets, output layout, and framework integrations.
 - Find the canonical repository and package registry for each SDK on the [SDKs page](/tx3/consuming/sdks).
-- Learn more about the [codegen workflow](/tx3/consuming/codegen) — supported targets, output layout, and how to wire generated code into your build.
+- If you can't run codegen — an ad-hoc script, generic tooling, a protocol you load at runtime — see [Dynamic Usage](/tx3/consuming/dynamic-usage) for the untyped SDK surface.
 - Understand the [protocols underneath](/tx3/advanced) (TII, TRP) if you want to know how the wire format works.

--- a/consuming/sdks.mdx
+++ b/consuming/sdks.mdx
@@ -6,9 +6,11 @@ sidebar:
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-A Tx3 SDK is the runtime library your application uses to consume a Tx3 protocol. It loads a compiled `.tii`, binds parties and signers, and drives the four-stage transaction lifecycle through a TRP server: `resolve → sign → submit → wait`.
+A Tx3 SDK is the runtime library your application uses to consume a Tx3 protocol. It provides the TRP transport, party and signer bindings, and the four-stage transaction lifecycle: `resolve → sign → submit → wait`.
 
-The conceptual surface is identical across every supported language; only the syntax differs. For a step-by-step walkthrough of that lifecycle in your language of choice, see the [Quick Start](/tx3/consuming/quick-start).
+A client produced by [`trix codegen`](/tx3/consuming/codegen) is a thin typed layer on top of this SDK — it delegates to the SDK for everything but the typed transaction methods. You can also use the SDK directly without codegen; see [Dynamic Usage](/tx3/consuming/dynamic-usage).
+
+The conceptual surface is identical across every supported language; only the syntax differs. For a step-by-step walkthrough in your language of choice, see the [Quick Start](/tx3/consuming/quick-start).
 
 This page is a directory: each supported language, where its source lives, and where to install it from.
 

--- a/index.mdx
+++ b/index.mdx
@@ -9,26 +9,28 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 Tx3 is an interface description format for UTxO blockchain protocols, plus the tooling to author and consume those interfaces. Protocol authors define a spec that declares what their protocol exposes; consumers read that spec and generate typed clients to build the transactions it accepts.
 
+## Software is about abstractions
+
+**In Web2**, an HTTP API is described with OpenAPI: a machine-readable spec listing every endpoint, the shape of each request, and the shape of each response. With that spec in hand, any consumer can generate a typed client and start calling the API without reading the server's source.
+
+**The EVM ecosystem** solves the same problem at the contract layer. Every contract publishes an ABI — a machine-readable description of the functions a consumer can call, the arguments each takes, and what each returns. The interface is data, not lore.
+
+## UTxO blockchains need an interface
+
+UTxO chains have nothing equivalent. A dApp is a set of validators that accept or reject transactions; nothing in the chain tells you which UTxOs to spend, which datums to attach, which redeemers to supply, which scripts to witness. That knowledge usually lives in the protocol author's head, or in a hand-written SDK that consumers have to reverse-engineer.
+
+Tx3 makes that knowledge a first-class, machine-readable artifact: the protocol's interface, written down.
+
 ## Pick your lane
 
 The same spec serves two audiences: the protocol author who publishes it, and the application developer who consumes it. The docs are organised around the two audiences. Start with the side that matches what you're trying to do.
 
 <CardGrid>
     <LinkCard icon="pencil" title="Authoring Protocols" href="/tx3/authoring" description="Write `.tx3` files describing the transactions your protocol exposes" />
-    <LinkCard icon="puzzle" title="Consuming Protocols" href="/tx3/consuming" description="Generate a typed client from a published `.tii` and integrate it into your application" />
+    <LinkCard icon="puzzle" title="Consuming Protocols" href="/tx3/consuming" description="Pull a published protocol with `trix use` and generate a typed client to integrate it into your application" />
 </CardGrid>
   
 Either way, start with [Installation](/tx3/installation) to get the toolchain on your machine.
-
-## Why UTxO protocols need this
-
-In Web2, an HTTP API is described with OpenAPI: a machine-readable spec listing every endpoint, the shape of each request, and the shape of each response. With that spec in hand, any consumer can generate a typed client and start calling the API without reading the server's source.
-
-The EVM ecosystem solves the same problem at the contract layer. Every contract publishes an ABI — a machine-readable description of the functions a consumer can call, the arguments each takes, and what each returns. The interface is data, not lore.
-
-UTxO chains have nothing equivalent. A dApp is a set of validators that accept or reject transactions; nothing in the chain tells you which UTxOs to spend, which datums to attach, which redeemers to supply, which scripts to witness. That knowledge usually lives in the protocol author's head, or in a hand-written SDK that consumers have to reverse-engineer.
-
-Tx3 makes that knowledge a first-class, machine-readable artifact: the protocol's interface, written down.
 
 ## What's in the toolkit
 

--- a/tooling/trix.mdx
+++ b/tooling/trix.mdx
@@ -47,6 +47,7 @@ Main commands:
 *   `trix invoke`: Invoke a transaction using CShell.
 *   `trix devnet`: Start a local development network.
 *   `trix explore`: Explore a network using CShell.
+*   `trix use`: Add a published protocol as an interface.
 *   `trix codegen`: Generate code to interact with your protocol.
 *   `trix check`: Check a Tx3 package and its dependencies for errors.
 *   `trix inspect`: Inspect the intermediate representation of a transaction
@@ -115,9 +116,33 @@ Usage:
 trix explore
 ```
 
+### `trix use`
+
+Add a published protocol to the project as an *interface* — a dependency you can generate a client for with `trix codegen`. The protocol is pulled from the registry, its compiled interface is cached locally, and a pinned entry is written to the `[interfaces]` table of `trix.toml`.
+
+Usage:
+
+```sh
+trix use <REFERENCE> [OPTIONS]
+```
+
+**Arguments:**
+
+- `<REFERENCE>`: Reference to pull, e.g. `acme/widget:0.1.0`. The version is optional and defaults to the `latest` tag; the resolved concrete version is pinned in `trix.toml`.
+
+**Options:**
+
+- `--alias <NAME>`: Local alias for this interface. Defaults to the reference's name.
+- `--force`: Replace an existing entry with the same alias.
+- `--dry-run`: Resolve and cache the artifact but do not modify `trix.toml`.
+
+Protocols resolve against the default registry (`https://oci.tx3.land`) unless `trix.toml` declares a `[registry]` section with a different `url`.
+
 ### `trix codegen`
 
 Generate code that can interact with your protocol by interpreting the interfaces defined by your Tx3 project. Code is generated from templates that use handlebars and can target multiple languages, including TypeScript, Rust, Go, and Python.
+
+Targets are declared in `trix.toml` under `[[codegen]]` entries, each pairing a `plugin` (`ts-client`, `rust-client`, `go-client`, or `python-client`) with an optional `output_dir`. A client is generated for the project's own protocol and for every interface added with `trix use`.
 
 Usage:
 


### PR DESCRIPTION
Reworks the **Consuming Protocols** section so the `trix use` + `trix codegen` codegen flow is the primary integration mechanism, with the dynamic/untyped SDK usage demoted to a brief dedicated page.

## Changes

- **`consuming/quick-start.mdx`** — rewritten as a codegen-first walkthrough: `trix use` → `[[codegen]]` config → `trix codegen` → install SDK → typed `Client` → `resolve → sign → submit → wait`. Tabbed across TypeScript, Rust, Go, and Python.
- **`consuming/codegen.mdx`** — added a `trix use` / interfaces section, documented the per-protocol output layout, reframed the cross-repo section.
- **`consuming/dynamic-usage.mdx`** — new small page covering the untyped runtime-SDK surface (`Protocol.fromFile` + `Tx3Client` + `tx("name").arg(...)`), for when codegen is not an option.
- **`consuming/index.mdx`** / **`consuming/sdks.mdx`** — reframed intro + new card; clarified runtime SDK vs. generated client.
- **`tooling/trix.mdx`** — documented `trix use` (previously undocumented), expanded the `trix codegen` entry.

## Config-schema fixes

The docs had drifted from the trix config code. Verified against `tooling/trix/src/config/{model,convention}.rs` and corrected:

- `[[bindings]]` → `[[codegen]]`
- `plugin = "typescript"` → `plugin = "ts-client"` (and `rust-client` / `go-client` / `python-client`)
- `output` → `output_dir`
- local TRP endpoint `http://localhost:3000/rpc` → `http://localhost:8164`
- profile name `devnet` → `local`

## ⚠️ Note for reviewers

The Quick Start describes a generated typed `Client` that owns the full `sign → submit → wait` lifecycle. The codegen templates currently emit a thinner client (typed `resolve` + raw `submit` only). This page is **intentionally written ahead** of a tracked follow-up that makes codegen emit the full facade. The `dynamic-usage.mdx` page is accurate to the shipping SDK today. The exact `Client` constructor / `withParty` / chain signatures should be reconciled with that follow-up before/as it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)