### PR TITLE
docs(consuming): refresh quick-start + dynamic-usage for the unified Tx3ClientBuilder

### DIFF
--- a/consuming/dynamic-usage.mdx
+++ b/consuming/dynamic-usage.mdx
@@ -24,63 +24,53 @@ Instead of importing a generated client, you load a compiled interface (`.tii`) 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
-    import { Protocol, TrpClient } from "tx3-sdk";
+    import { Protocol } from "tx3-sdk";
 
     const protocol = await Protocol.fromFile("./transfer.tii");
-    const trp = new TrpClient({ endpoint: "http://localhost:8164" });
     ```
   </TabItem>
   <TabItem label="Rust">
     ```rust
-    use tx3_sdk::trp::{Client, ClientOptions};
-
     let protocol = tx3_sdk::tii::Protocol::from_file("./transfer.tii")?;
-    let trp = Client::new(ClientOptions {
-        endpoint: "http://localhost:8164".to_string(),
-        headers: None,
-    });
     ```
   </TabItem>
   <TabItem label="Go">
     ```go
-    import (
-        tx3 "github.com/tx3-lang/go-sdk/sdk"
-        "github.com/tx3-lang/go-sdk/sdk/trp"
-    )
+    import tx3 "github.com/tx3-lang/go-sdk/sdk"
 
     protocol, err := tx3.ProtocolFromFile("./transfer.tii")
     if err != nil { log.Fatal(err) }
-
-    trpClient := tx3.NewTRPClient(trp.ClientOptions{
-        Endpoint: "http://localhost:8164",
-    })
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
-    from tx3_sdk import Protocol, TrpClient
+    from tx3_sdk import Protocol
 
     protocol = Protocol.from_file("./transfer.tii")
-    trp = TrpClient(endpoint="http://localhost:8164")
     ```
   </TabItem>
 </Tabs>
 
-## Drive a transaction
+## Build a client and drive a transaction
 
-Build the client with `Tx3Client`, bind parties and a profile, then address the transaction by name with `tx("...")` and supply each argument with `arg(...)`. From there the lifecycle is identical to the typed flow: `resolve → sign → submit → wait`.
+`protocol.client()` returns a builder seeded with the protocol's transactions, profiles, and declared parties. Configure the TRP endpoint, select a profile, and bind parties — `Party.signer(...)` for keys that produce witnesses, `Party.address(...)` for read-only addresses — then call `.build()` to materialize a `Tx3Client`. All fallible validation (endpoint present, profile declared, every party declared) happens at `build()` time; the optional setters never fail.
+
+From the built client, address each transaction by string name with `tx("...")` and supply each argument with `arg(...)`. From there the lifecycle is identical to the typed flow: `resolve → sign → submit → wait`.
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
     ```ts
-    import { Tx3Client, Party, Ed25519Signer, PollConfig } from "tx3-sdk";
+    import { Party, Ed25519Signer, PollConfig } from "tx3-sdk";
 
     const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
 
-    const tx3 = new Tx3Client(protocol, trp)
+    const tx3 = protocol
+      .client()
+      .trpEndpoint("http://localhost:8164")
       .withProfile("local")
       .withParty("sender", Party.signer(signer))
-      .withParty("receiver", Party.address("addr_test1..."));
+      .withParty("receiver", Party.address("addr_test1..."))
+      .build();
 
     const status = await tx3
       .tx("transfer")
@@ -94,17 +84,20 @@ Build the client with `Tx3Client`, bind parties and a profile, then address the 
   <TabItem label="Rust">
     ```rust
     use serde_json::json;
-    use tx3_sdk::{CardanoSigner, Party, PollConfig, Tx3Client};
+    use tx3_sdk::{CardanoSigner, Party, PollConfig};
 
     let signer = CardanoSigner::from_mnemonic("addr_test1...", "word1 ... word24")?;
 
-    let tx3 = Tx3Client::new(protocol, trp)
+    let tx3 = protocol
+        .client()
+        .trp_endpoint("http://localhost:8164")
         .with_profile("local")
         .with_party("sender", Party::signer(signer))
-        .with_party("receiver", Party::address("addr_test1..."));
+        .with_party("receiver", Party::address("addr_test1..."))
+        .build()?;
 
     let status = tx3
-        .tx("transfer")
+        .tx("transfer")?
         .arg("quantity", json!(10_000_000))
         .resolve()
         .await?
@@ -117,17 +110,26 @@ Build the client with `Tx3Client`, bind parties and a profile, then address the 
   </TabItem>
   <TabItem label="Go">
     ```go
-    import "github.com/tx3-lang/go-sdk/sdk/signer"
+    import (
+        "context"
+        tx3 "github.com/tx3-lang/go-sdk/sdk"
+        "github.com/tx3-lang/go-sdk/sdk/facade"
+        "github.com/tx3-lang/go-sdk/sdk/signer"
+    )
 
     mySigner, _ := signer.CardanoSignerFromMnemonic("addr_test1...", "word1 ... word24")
 
-    client := tx3.NewClient(protocol, trpClient).
+    client, err := tx3.ProtocolClient(protocol).
+        TRPEndpoint("http://localhost:8164").
         WithProfile("local").
-        WithParty("sender", tx3.SignerParty(mySigner)).
-        WithParty("receiver", tx3.AddressParty("addr_test1..."))
+        WithParty("sender", facade.SignerParty(mySigner)).
+        WithParty("receiver", facade.AddressParty("addr_test1...")).
+        Build()
+    if err != nil { log.Fatal(err) }
 
     ctx := context.Background()
-    resolved, _ := client.Tx("transfer").Arg("quantity", 10_000_000).Resolve(ctx)
+    b, _ := client.Tx("transfer")
+    resolved, _ := b.Arg("quantity", 10_000_000).Resolve(ctx)
     signed, _ := resolved.Sign()
     submitted, _ := signed.Submit(ctx)
     status, _ := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())
@@ -135,15 +137,17 @@ Build the client with `Tx3Client`, bind parties and a profile, then address the 
   </TabItem>
   <TabItem label="Python">
     ```python
-    from tx3_sdk import CardanoSigner, Party, PollConfig, Tx3Client
+    from tx3_sdk import CardanoSigner, Party, PollConfig
 
     signer = CardanoSigner.from_mnemonic(address="addr_test1...", phrase="word1 ... word24")
 
     client = (
-        Tx3Client(protocol, trp)
+        protocol.client()
+        .trp_endpoint("http://localhost:8164")
         .with_profile("local")
         .with_party("sender", Party.signer(signer))
         .with_party("receiver", Party.address("addr_test1..."))
+        .build()
     )
 
     resolved = await client.tx("transfer").arg("quantity", 10_000_000).resolve()
@@ -153,6 +157,10 @@ Build the client with `Tx3Client`, bind parties and a profile, then address the 
     ```
   </TabItem>
 </Tabs>
+
+<Aside type="note">
+Go uses `tx3.ProtocolClient(protocol)` (equivalently `facade.FromProtocol(protocol)`) instead of `protocol.Client()`. The method-on-Protocol shape would create a `tii → facade → tii` import cycle in Go; the other SDKs expose `protocol.client()` directly.
+</Aside>
 
 <Aside type="tip">
 If the protocol is known at build time, prefer [codegen](/tx3/consuming/codegen) — you get the same lifecycle with typed transaction methods and compile-time argument checking.

--- a/consuming/quick-start.mdx
+++ b/consuming/quick-start.mdx
@@ -101,7 +101,7 @@ The generated client is a thin typed layer: it delegates to the runtime SDK for 
     ```toml
     # Cargo.toml
     [dependencies]
-    tx3-sdk = "0.9"
+    tx3-sdk = "0.12"
     ```
   </TabItem>
   <TabItem label="Go">
@@ -118,7 +118,7 @@ The generated client is a thin typed layer: it delegates to the runtime SDK for 
 
 ## Construct the client
 
-The generated `Client` already embeds the protocol interface, so you only give it a TRP endpoint, a profile, and party bindings. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address. `withProfile(...)` selects which environment block (`local`/`preview`/`preprod`/`mainnet`) the SDK uses when it asks TRP to resolve.
+The generated `Client` already embeds the protocol interface. The constructor takes the TRP transport options and a typed `Profile` value (the environment block — `local` / `preview` / `preprod` / `mainnet` — the SDK uses when it asks TRP to resolve). Profile selection is **locked in at construction**; switching profiles requires a new `Client`. Per-party setters are typed, one method per declared party — for the `transfer` protocol that means `withSender(...)` and `withReceiver(...)`, each taking a `Party`. `Party.signer(...)` ties a party to a key that can produce witnesses; `Party.address(...)` binds a read-only address.
 
 Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP39 mnemonic at the standard Cardano path, and a generic `Ed25519Signer` for raw key material. The snippets below show whichever flavour is most idiomatic per language.
 
@@ -130,26 +130,31 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
 
     const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");
 
-    const client = new Client({ endpoint: "http://localhost:8164" })
-      .withProfile("local")
-      .withParty("sender", Party.signer(signer))
-      .withParty("receiver", Party.address("addr_test1..."));
+    const client = new Client({ endpoint: "http://localhost:8164" }, "local")
+      .withSender(Party.signer(signer))
+      .withReceiver(Party.address("addr_test1..."));
     ```
   </TabItem>
   <TabItem label="Rust">
     ```rust
     use tx3_sdk::{CardanoSigner, Party};
-    use transfer::Client;
+    use tx3_sdk::trp::ClientOptions;
+    use transfer::{Client, Profile};
 
     let signer = CardanoSigner::from_mnemonic(
         "addr_test1...",
         "word1 word2 ... word24",
     )?;
 
-    let client = Client::new("http://localhost:8164")
-        .with_profile("local")
-        .with_party("sender", Party::signer(signer))
-        .with_party("receiver", Party::address("addr_test1..."));
+    let client = Client::new(
+            ClientOptions {
+                endpoint: "http://localhost:8164".into(),
+                headers: None,
+            },
+            Profile::Local,
+        )
+        .with_sender(Party::signer(signer))
+        .with_receiver(Party::address("addr_test1..."));
     ```
   </TabItem>
   <TabItem label="Go">
@@ -157,6 +162,7 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     import (
         tx3 "github.com/tx3-lang/go-sdk/sdk"
         "github.com/tx3-lang/go-sdk/sdk/signer"
+        "github.com/tx3-lang/go-sdk/sdk/trp"
         "yourapp/gen/transfer"
     )
 
@@ -166,16 +172,18 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     )
     if err != nil { log.Fatal(err) }
 
-    client := transfer.NewClient("http://localhost:8164").
-        WithProfile("local").
-        WithParty("sender", tx3.SignerParty(mySigner)).
-        WithParty("receiver", tx3.AddressParty("addr_test1..."))
+    client := transfer.NewClient(
+        trp.ClientOptions{Endpoint: "http://localhost:8164"},
+        transfer.ProfileLocal,
+    ).
+        WithSender(tx3.SignerParty(mySigner)).
+        WithReceiver(tx3.AddressParty("addr_test1..."))
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
-    from tx3_sdk import CardanoSigner, Party
-    from gen.transfer import Client
+    from tx3_sdk import CardanoSigner, ClientOptions, Party
+    from gen.transfer import Client, Profile
 
     sender_signer = CardanoSigner.from_mnemonic(
         address="addr_test1...",
@@ -183,10 +191,9 @@ Each SDK ships two signer kinds: a `CardanoSigner` that derives keys from a BIP3
     )
 
     client = (
-        Client(endpoint="http://localhost:8164")
-        .with_profile("local")
-        .with_party("sender", Party.signer(sender_signer))
-        .with_party("receiver", Party.address("addr_test1..."))
+        Client(ClientOptions(endpoint="http://localhost:8164"), Profile.LOCAL)
+        .with_sender(Party.signer(sender_signer))
+        .with_receiver(Party.address("addr_test1..."))
     )
     ```
   </TabItem>


### PR DESCRIPTION
## Summary

The SDK fleet shipped **0.12** with the unified `Tx3ClientBuilder` (see the runtime SDK release notes for [rust-sdk](https://github.com/tx3-lang/rust-sdk/releases/tag/v0.12.0) / [web-sdk](https://github.com/tx3-lang/web-sdk/releases/tag/v0.12.0) / [python-sdk](https://github.com/tx3-lang/python-sdk/releases/tag/v0.12.0) / [go-sdk](https://github.com/tx3-lang/go-sdk/releases/tag/sdk%2Fv0.12.0)). Two consuming docs still showed the pre-port APIs.

### `consuming/quick-start.mdx` (codegen flow)

- Rust install snippet bumped `"0.9"` → `"0.12"`.
- **Construct the client** section rewritten for the new generated-`Client` shape:
  - Constructor is now `Client(options, profile)` where `profile` is a typed `Profile` enum — locked in at construction; switching profiles requires a new `Client`.
  - Per-party setters are typed (one method per declared party): for the `transfer` example, `withSender(...)` and `withReceiver(...)`. Generated wrappers no longer expose a generic `withParty(name, ...)` (per [`sdk-spec/codegen/generated-surface.md`](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/codegen/generated-surface.md)).
  - Narrative reframed: profile is no longer a chainable setter on the generated client.

### `consuming/dynamic-usage.mdx`

- **Load the protocol** simplified — dropped the separate `new TrpClient(...)` construction; the builder now owns TRP-client lifetime.
- **Drive a transaction** rewritten around the unified builder: `protocol.client().trpEndpoint(...).withProfile(...).withParty(...).build()`.
- Go example uses `tx3.ProtocolClient(protocol)...Build()` and the new `Tx(name) (b, error)` signature.
- Added a Go-only Aside flagging the `tx3.ProtocolClient(p)` vs `protocol.client()` naming difference (Go avoids a `tii → facade → tii` import cycle; other SDKs expose `protocol.client()` directly).

### Untouched

`codegen.mdx`, `sdks.mdx`, `index.mdx`, `_meta.yml` — no API-shape drift; the narrative there still reads accurately against post-port reality.

## Test plan

- [x] Verified code snippets compile against the actual generated-template shape for each SDK at v0.12.0 (`tx3c codegen` against the test-vector `transfer.tii`).
- [ ] Render a preview locally (`npm run dev` or equivalent) to confirm syntax-highlighting + tab rendering still work for the rewritten code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)