### PR TITLE
docs(language): document /// doc-comments

### DIFF
--- a/language/comments.md
+++ b/language/comments.md
@@ -1,0 +1,60 @@
+---
+title: Comments
+sidebar:
+    order: 9
+---
+
+Tx3 has three kinds of comments: regular line comments, block comments, and doc-comments. The first two are stripped during parsing and have no effect beyond letting you annotate the source. Doc-comments are different — they are preserved and surfaced by downstream tooling (the registry UI, generated bindings, etc.).
+
+## Line and block comments
+
+```tx3
+// A line comment runs to the end of the line.
+
+/*
+   A block comment runs until the matching */.
+   Block comments do not nest, so the first */ closes them.
+*/
+```
+
+Use these for notes to other authors. They never make it past the parser.
+
+## Doc-comments
+
+A *doc-comment* begins with `///` and runs to the end of the line. Place one (or several consecutive ones) immediately before a declaration to document it:
+
+```tx3
+/// The user who initiates the transaction.
+party User;
+
+env {
+    /// The Cardano network magic identifier.
+    network: Int,
+}
+
+/// Transfer lovelace from the user to the treasury.
+/// Fees are deducted from the user's input UTxO.
+tx pay(
+    /// Amount to transfer, in lovelace.
+    quantity: Int,
+) {
+    // ...
+}
+```
+
+Doc-comments may attach to:
+
+- a `party` declaration,
+- an `env` field,
+- a `tx` declaration, and
+- a parameter inside a `tx` parameter list.
+
+Multiple consecutive `///` lines are concatenated into a single docstring, in source order, joined with line breaks. A single leading space after the `///` is stripped from each line, so `/// foo` and `///foo` both yield `foo`.
+
+A `///` line in any other position is a syntax error. If you want a free-floating comment that the parser ignores, use `//`.
+
+## Where doc-comments show up
+
+The compiler carries doc-comments through to the published [TII artefact](/advanced/tii): party docstrings become `Party.description`, transaction docstrings become `Transaction.description`, and env-field and tx-parameter docstrings become the `description` of the corresponding JSON Schema property. From there, the registry surfaces them in the protocol detail page and codegen frontends can embed them in generated bindings.
+
+If you want a description to appear next to a name in the registry UI or in your generated SDK, write it as a `///` doc-comment in the source.

--- a/language/env.md
+++ b/language/env.md
@@ -65,6 +65,22 @@ tx mint_from_env(
 
 Here `mint_script` and `mint_policy` are typed env values; the parser checks that `mint_script` has type `UtxoRef` wherever a `UtxoRef` is required, and that `mint_policy` has type `Bytes` wherever a policy id is expected.
 
+## Documenting env fields
+
+Prefix any field with a `///` doc-comment to describe what value belongs there. The description follows the field through to the registry UI and generated bindings, which helps integrators fill in profiles correctly:
+
+```tx3
+env {
+    /// Cardano network magic identifier.
+    network: Int,
+
+    /// UTxO that hosts the minting script's reference output.
+    mint_script: UtxoRef,
+}
+```
+
+See [Comments](./comments) for the full rules.
+
 ## How env values get supplied
 
 The Tx3 language only declares the shape of the environment. The concrete values are supplied by the toolchain — typically by `trix` from a profile-specific env file. See the project guide for how to wire env values per network.

--- a/language/index.mdx
+++ b/language/index.mdx
@@ -44,3 +44,9 @@ The core declaration in a Tx3 file is a `tx`: a parameterised template that the 
 A few constructs only make sense on one chain. Cardano-specific blocks live under the `cardano::` namespace — `cardano::withdrawal`, `cardano::plutus_witness`, `cardano::publish`, certificate blocks, and so on.
 
 <LinkCard title="Cardano Features" href="language/cardano" description="Stake operations, witnesses, treasury donations, reference-script publishing" />
+
+## Documenting your protocol
+
+Doc-comments (`///`) attach to a `party`, an `env` field, a `tx`, or a tx parameter and travel with the protocol all the way to the registry UI and generated bindings.
+
+<LinkCard title="Comments" href="language/comments" description="Line, block, and doc-comments — and where doc-comments end up" />

--- a/language/parties.md
+++ b/language/parties.md
@@ -54,6 +54,20 @@ tx transfer(
 }
 ```
 
+## Documenting a party
+
+Prefix a party declaration with a `///` doc-comment to describe its role. The description is carried through to the registry UI and generated bindings:
+
+```tx3
+/// The user initiating the transaction.
+party Sender;
+
+/// Protocol treasury — receives fees and dust.
+party Treasury;
+```
+
+See [Comments](./comments) for the full rules.
+
 ## Parties vs. policies
 
 When the address that controls a UTxO is itself a script, declare it as a [`policy`](./policies) rather than a party. A `party` is the right tool for an actor whose address you don't yet know; a `policy` is the right tool for a script whose hash or witness you do.

--- a/language/txs.md
+++ b/language/txs.md
@@ -44,6 +44,23 @@ tx transfer(
 
 Two identifiers are pre-bound inside every `tx` body: `Ada` (the chain's primary asset, used as a constructor) and `fees` (the resolved transaction fee, an `AnyAsset` value).
 
+## Documenting a tx and its parameters
+
+Prefix the `tx` keyword — or any parameter inside the parameter list — with a `///` doc-comment to describe what the transaction does and what each parameter means. The descriptions are surfaced in the registry UI and in generated bindings:
+
+```tx3
+/// Transfer lovelace from the sender to the receiver.
+/// Any change is returned to the sender.
+tx transfer(
+    /// Amount to transfer, in lovelace.
+    quantity: Int,
+) {
+    // ...
+}
+```
+
+Multiple consecutive `///` lines are joined with line breaks. See [Comments](./comments) for the full rules.
+
 ## `input` — a UTxO to consume
 
 ```tx3


### PR DESCRIPTION
## Summary
End-user documentation for the `///` doc-comment feature that landed in [tx3-lang/tx3#329](https://github.com/tx3-lang/tx3/pull/329) and is spec'd in [tx3-lang/tx3#330](https://github.com/tx3-lang/tx3/pull/330).

- New `language/comments.md` (sidebar order 9) covers all three comment kinds: `//`, `/* */`, and `///`. It explains the four positions where a doc-comment is permitted (party, env field, tx, tx parameter), the multi-line concatenation rule, the single leading-space strip, and where doc-comments surface downstream (TII → registry UI → generated bindings).
- `language/index.mdx` gains a "Documenting your protocol" section with a `<LinkCard>` to the new page.
- `language/parties.md`, `language/env.md`, and `language/txs.md` each get a short "Documenting …" subsection with an inline example, so the feature is discoverable from each construct's reference page.

## Why
Without this PR the feature is invisible to authors: the registry UI shows their docstrings, but nothing in the language guide tells them how to write one.

## Test plan
- [ ] `pnpm dev` (or whatever the docs site uses) and skim the rendered Language Guide pages for layout/links.
- [ ] Confirm the new sidebar entry appears in order (Comments after Cardano Features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)