### PR TITLE
docs: rewrite consumer flow around trix use bootstrap and codegen --plugin

### DIFF
--- a/consuming/quick-start.mdx
+++ b/consuming/quick-start.mdx
@@ -10,7 +10,7 @@ This guide walks through consuming an existing Tx3 protocol from your applicatio
 
 We're assuming you already have:
 
-- A Tx3 project — a directory with a `trix.toml`. `trix codegen` runs inside a project, so if you don't have one yet, run `trix init` to scaffold it.
+- An empty directory to work in. `trix use` bootstraps a minimal consumer-shape `trix.toml` automatically when none is found; if you're already inside an existing Tx3 project it pins into that one instead. (Authors who want the full project skeleton with `main.tx3` and tests still use `trix init`.)
 - A TRP server reachable from your machine. The simplest setup is `trix devnet`, which exposes a local TRP endpoint at `http://localhost:8164`; for testnet/mainnet, point at a hosted TRP endpoint (Demeter, Blockfrost-via-TRP, etc.).
 - The toolchain for your target language installed (Node.js 18+, Rust 1.78+, Go 1.22+, or Python 3.10+).
 
@@ -40,50 +40,36 @@ The `digest` locks the exact artifact, so every machine and CI run generates a c
 Protocols resolve against the default registry (`https://oci.tx3.land`). To use a different one, add a `[registry]` section with a `url` to `trix.toml`.
 </Aside>
 
-## Configure codegen
+## Generate the client
 
-Add a `[[codegen]]` entry to `trix.toml` for each target language. `plugin` selects the language; `output_dir` is where generated code is written — it's optional and defaults to `.tx3/codegen/<plugin>/`. Declare more than one entry to target multiple languages from the same project.
+Pick a language and let `trix codegen` add the matching `[[codegen]]` entry to `trix.toml` on first run, then generate:
 
 <Tabs syncKey="lang">
   <TabItem label="TypeScript">
-    ```toml
-    [[codegen]]
-    plugin = "ts-client"
-    output_dir = "src/gen"
+    ```sh
+    trix codegen --plugin ts-client
     ```
   </TabItem>
   <TabItem label="Rust">
-    ```toml
-    [[codegen]]
-    plugin = "rust-client"
-    output_dir = "src/gen"
+    ```sh
+    trix codegen --plugin rust-client
     ```
   </TabItem>
   <TabItem label="Go">
-    ```toml
-    [[codegen]]
-    plugin = "go-client"
-    output_dir = "gen"
+    ```sh
+    trix codegen --plugin go-client
     ```
   </TabItem>
   <TabItem label="Python">
-    ```toml
-    [[codegen]]
-    plugin = "python-client"
-    output_dir = "gen"
+    ```sh
+    trix codegen --plugin python-client
     ```
   </TabItem>
 </Tabs>
 
-## Generate the client
+Subsequent runs can drop the flag — bare `trix codegen` re-emits every configured target. To customize where output lands, edit the `output_dir` on the `[[codegen]]` entry in `trix.toml` (it defaults to `.tx3/codegen/<plugin>/`). Add a second `--plugin` invocation to target multiple languages from one project.
 
-From the project root, run:
-
-```sh
-trix codegen
-```
-
-This writes one typed module per protocol under `output_dir`: your own project lands in `<output_dir>/<project-name>/`, and each interface added with `trix use` lands in `<output_dir>/<alias>/` — so the `transfer` interface above is generated into `src/gen/transfer/`. Each module embeds the compiled interface (transactions, parties, profiles) and exposes one typed method per `tx` the protocol declares.
+This writes one typed module per protocol under `output_dir`: your own project lands in `<output_dir>/<project-name>/`, and each interface added with `trix use` lands in `<output_dir>/<alias>/` — so the `transfer` interface above is generated into `.tx3/codegen/ts-client/transfer/` (or wherever you set `output_dir`). Each module embeds the compiled interface (transactions, parties, profiles), exposes one typed method per `tx` the protocol declares, and ships a `README.md` with the language-specific install instructions.
 
 Re-run `trix codegen` whenever you `trix use` a new version of an interface. The generated code is meant to be checked into source control alongside your application — treat it like a lockfile, not a build artifact.
 

--- a/tooling/trix.mdx
+++ b/tooling/trix.mdx
@@ -120,6 +120,8 @@ trix explore
 
 Add a published protocol to the project as an *interface* — a dependency you can generate a client for with `trix codegen`. The protocol is pulled from the registry, its compiled interface is cached locally, and a pinned entry is written to the `[interfaces]` table of `trix.toml`.
 
+If no `trix.toml` is found in the current directory or any ancestor, `trix use` bootstraps a minimal consumer-shape project (a `trix.toml` with no `main.tx3`, no tests, no owner scope) and pins the interface into it. Pass `--no-init` to opt out — useful in CI where a missing project should fail loudly.
+
 Usage:
 
 ```sh
@@ -135,6 +137,7 @@ trix use <REFERENCE> [OPTIONS]
 - `--alias <NAME>`: Local alias for this interface. Defaults to the reference's name.
 - `--force`: Replace an existing entry with the same alias.
 - `--dry-run`: Resolve and cache the artifact but do not modify `trix.toml`.
+- `--no-init`: Refuse to auto-bootstrap a project when no `trix.toml` is found; error instead.
 
 Protocols resolve against the default registry (`https://oci.tx3.land`) unless `trix.toml` declares a `[registry]` section with a different `url`.
 
@@ -142,13 +145,20 @@ Protocols resolve against the default registry (`https://oci.tx3.land`) unless `
 
 Generate code that can interact with your protocol by interpreting the interfaces defined by your Tx3 project. Code is generated from templates that use handlebars and can target multiple languages, including TypeScript, Rust, Go, and Python.
 
-Targets are declared in `trix.toml` under `[[codegen]]` entries, each pairing a `plugin` (`ts-client`, `rust-client`, `go-client`, or `python-client`) with an optional `output_dir`. A client is generated for the project's own protocol and for every interface added with `trix use`.
+Targets live in `trix.toml` under `[[codegen]]` entries, each pairing a `plugin` (`ts-client`, `rust-client`, `go-client`, or `python-client`) with an optional `output_dir`. `trix codegen` is the canonical way to add the first target: passing `--plugin <name>` appends a matching `[[codegen]]` entry to `trix.toml` (if one does not already exist) and then generates. Hand-editing `trix.toml` remains supported — useful for custom plugins or a bespoke `output_dir`. A client is generated for the project's own protocol and for every interface added with `trix use`.
+
+If no targets are configured and `--plugin` is not passed, `trix codegen` prompts interactively when run from a terminal. In non-interactive contexts it errors and points at `--plugin`.
 
 Usage:
 
 ```sh
-trix codegen
+trix codegen [OPTIONS]
 ```
+
+**Options:**
+
+- `--plugin <NAME>`: Seed a `[[codegen]]` entry for this plugin (`ts-client` / `rust-client` / `go-client` / `python-client`) if one does not already exist, then generate. Unknown values fail with a suggestion before any codegen runs.
+- `--no-save`: Generate without persisting a newly-seeded `[[codegen]]` entry back to `trix.toml`. Intended for CI / scripted one-offs.
 
 ### `trix check`
 


### PR DESCRIPTION
## Summary

- **`consuming/quick-start.mdx`**: drop the `trix init` precondition (`trix use` now auto-bootstraps a consumer-shape project) and replace the manual \"add a `[[codegen]]` entry to `trix.toml`\" TOML block with `trix codegen --plugin <name>`, which seeds the entry on first run.
- **`tooling/trix.mdx`**: document `trix use --no-init`, `trix codegen --plugin`/`--no-save`, the interactive prompt fallback, and the unchanged escape hatch of hand-editing `[[codegen]]` for custom plugins or bespoke `output_dir`.

Pairs with the trix CLI PR (consumer bootstrap + `trix codegen --plugin`) and the per-SDK `README.md.hbs` PRs.

## Test plan

- [ ] Render the Starlight site locally; walk through the Quick Start tabs and confirm the snippet shows the two-step flow per language
- [ ] Confirm the Trix command reference renders the new `--plugin` / `--no-save` / `--no-init` options