### PR TITLE
docs: document the multiply (*) operator

### DIFF
--- a/language/assets.md
+++ b/language/assets.md
@@ -84,6 +84,15 @@ Conceptually each operand is a bag of `(policy, asset_name, amount)` entries; ad
 
 The value attached to an input or reference participates in the same arithmetic: `source - Ada(quantity) - fees` makes sense because `source` is an asset value.
 
+## Scaling
+
+Multiplying an `AnyAsset` by an `Int` scales every entry's amount. The `Int` may be on either side, and `*` binds tighter than `+` and `-`:
+
+```tx3
+StaticAsset(50) * quantity
+Ada(2000000) + StaticAsset(1) * count
+```
+
 ## Reading asset components
 
 An `AnyAsset` exposes three properties:

--- a/language/data.md
+++ b/language/data.md
@@ -47,6 +47,7 @@ The operator surface is small.
 | `expr.identifier` | Property access. Available on records, variant struct cases, `AnyAsset`, and `UtxoRef`. |
 | `expr[expr]`      | List indexing. The index expression must have type `Int`.                               |
 | `!expr`           | Arithmetic negation. Applies to `Int`.                                                  |
+| `a * b`           | Multiplication. `Int * Int` multiplies integers; `AnyAsset * Int` (and `Int * AnyAsset`) scales asset quantities. |
 | `a + b`           | Addition. `Int + Int` adds integers; `AnyAsset + AnyAsset` aggregates asset values.     |
 | `a - b`           | Subtraction. Same shapes as `+`.                                                        |
 
@@ -54,9 +55,10 @@ Precedence, from tightest to loosest:
 
 1. Postfix `.` and `[…]`.
 2. Prefix `!`.
-3. Infix `+` and `-`.
+3. Infix `*`.
+4. Infix `+` and `-`.
 
-Parentheses override precedence. There are no comparison, logical, multiplication, division, or ternary operators in this version of the language.
+Parentheses override precedence. There are no comparison, logical, division, or ternary operators in this version of the language.
 
 ## Constructors
 


### PR DESCRIPTION
## Summary

Documents the new multiply (`*`) operator.

- `language/data.md`: adds the `a * b` row to the operators table, inserts `*` into the precedence list (tighter than `+`/`-`), and removes "multiplication" from the list of unsupported operators.
- `language/assets.md`: new "Scaling" section showing `AnyAsset * Int` quantity scaling.

Pairs with the language implementation in tx3-lang/tx3#339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
