### PR TITLE
docs: document the divide (/) operator

### DIFF
--- a/language/assets.md
+++ b/language/assets.md
@@ -93,6 +93,12 @@ StaticAsset(50) * quantity
 Ada(2000000) + StaticAsset(1) * count
 ```
 
+Dividing an `AnyAsset` by an `Int` scales every entry's amount down by integer division (truncating toward zero — remainders are dropped). The divisor must be on the right (`AnyAsset / Int`), and `/` shares precedence with `*`:
+
+```tx3
+total_pot / participants
+```
+
 ## Reading asset components
 
 An `AnyAsset` exposes three properties:

--- a/language/data.md
+++ b/language/data.md
@@ -48,6 +48,7 @@ The operator surface is small.
 | `expr[expr]`      | List indexing. The index expression must have type `Int`.                               |
 | `!expr`           | Arithmetic negation. Applies to `Int`.                                                  |
 | `a * b`           | Multiplication. `Int * Int` multiplies integers; `AnyAsset * Int` (and `Int * AnyAsset`) scales asset quantities. |
+| `a / b`           | Integer division, truncating toward zero (`7 / 2` is `3`). `Int / Int` divides integers; `AnyAsset / Int` divides each asset quantity. Does not commute (`Int / AnyAsset` is invalid). Dividing by `0` is an error. |
 | `a + b`           | Addition. `Int + Int` adds integers; `AnyAsset + AnyAsset` aggregates asset values.     |
 | `a - b`           | Subtraction. Same shapes as `+`.                                                        |
 
@@ -55,10 +56,12 @@ Precedence, from tightest to loosest:
 
 1. Postfix `.` and `[…]`.
 2. Prefix `!`.
-3. Infix `*`.
+3. Infix `*` and `/`.
 4. Infix `+` and `-`.
 
-Parentheses override precedence. There are no comparison, logical, division, or ternary operators in this version of the language.
+Parentheses override precedence. There are no comparison, logical, modulo, or ternary operators in this version of the language.
+
+> **`/` and comments:** `//` starts a line comment and `/*` starts a block comment, so write division with a single slash (`a / b`). The token sequence `a//b` is parsed as `a` followed by a comment, not as division.
 
 ## Constructors
 


### PR DESCRIPTION
## Summary

Documents the new `/` operator alongside `*`.

- `language/data.md`: `a / b` operators-table row (integer division, truncates toward zero, `AnyAsset / Int`, non-commutative, divide-by-zero error); `/` added to precedence level 3; a callout that `a//b` is a comment, not division.
- `language/assets.md`: a short `total_pot / participants` scaling-down example noting truncation drops remainders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)